### PR TITLE
Add Python extraction toolkit and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,115 @@
-# butterknife
+# Butter Knife
+
+Butter Knife is a production-grade Flutter application that finds and saves images or videos from any web page. The project bundles store-ready copy, a full engineering roadmap, and implementation principles so the team can move straight into delivery.
+
+## Documentation Map
+
+- [`docs/STORE_DESCRIPTION.md`](docs/STORE_DESCRIPTION.md) — Complete App Store / Play Store metadata, including feature highlights and usage workflow.
+- [`docs/ENGINEERING_PLAN.md`](docs/ENGINEERING_PLAN.md) — Senior-level implementation plan broken down into epics, tickets, acceptance bars, and execution notes.
+
+## Store Snapshot
+
+| Field | Value |
+| --- | --- |
+| Name | **Butter Knife — Bulk Image & Video Saver** |
+| Short description | Collect images and videos from any web page. Preview, pick, and save. |
+| iOS subtitle | Bulk media downloader |
+| Primary permission rationale | Photos/Storage access is required so downloads can be written to the device gallery. |
+
+Refer to the store description document for the full-length marketing copy, feature breakdown, and usage workflow.
+
+## Product Highlights
+
+- **One-tap processing** with a dedicated button and overlay feedback while the DOM is analyzed.
+- **Smart filtering** that skips sub-10 KB assets and favicons so the gallery only shows meaningful media.
+- **Video awareness**, capturing `<video>` posters and sources alongside images.
+- **Grid-first browsing** that supports bulk selection plus single-item saves.
+- **Download flexibility**, including "Download All" and per-item saves with a persistent history.
+
+## End-to-End User Flow
+
+1. Launch the app and paste a page URL or open it directly in the in-app WebView.
+2. Tap **Process** and watch the overlay progress through DOM scanning, normalization, and probing.
+3. Review the resulting media grid, select any subset, or choose **Download All**.
+4. Save items to the Photos/Gallery destination that matches the platform defaults.
+5. Return to the landing screen and repeat for the next page.
+
+## Technology Stack & Key Dependencies
+
+Butter Knife targets Android 8+ and iOS 14+ using Flutter (stable channel) with the following production libraries:
+
+| Area | Package(s) | Purpose |
+| --- | --- | --- |
+| State & navigation | [`get`](https://pub.dev/packages/get) | Binding-driven state management and navigation. |
+| Networking | [`dio`](https://pub.dev/packages/dio) | Robust HTTP client for HEAD/GET probing with interceptors and retry support. |
+| Web content | [`webview_flutter`](https://pub.dev/packages/webview_flutter) | Embeds the WebView with JavaScript bridge support. |
+| DOM parsing | [`html`](https://pub.dev/packages/html) | Parses markup when we need to inspect responses outside the WebView. |
+| Persistence | [`path_provider`](https://pub.dev/packages/path_provider), [`shared_preferences`](https://pub.dev/packages/shared_preferences) | Resolve filesystem paths and persist user preferences such as thresholds and concurrency. |
+| Permissions | [`permission_handler`](https://pub.dev/packages/permission_handler) | Unified runtime permission flows across Android and iOS. |
+| Downloads | [`flutter_downloader`](https://pub.dev/packages/flutter_downloader) (Android), platform channels, [`photo_manager`](https://pub.dev/packages/photo_manager) | Queue management, background support, and saving media into gallery destinations. |
+| Media presentation | [`cached_network_image`](https://pub.dev/packages/cached_network_image) | Efficient thumbnail caching in the grid. |
+
+The implementation plan calls out version-specific behaviors (e.g., Android scoped storage, iOS Photos album creation). Always verify plugin compatibility against the targeted Flutter stable release before upgrading.
+
+## Engineering Execution
+
+The full roadmap in [`docs/ENGINEERING_PLAN.md`](docs/ENGINEERING_PLAN.md) is organized as a series of epics that cover architecture, WebView integration, media extraction, filtering, UI, downloads, platform integration, settings, telemetry, QA, and store readiness. Each ticket has explicit acceptance criteria so teams can ship incremental, production-quality slices without placeholders or stubs.
+
+Key delivery expectations include:
+
+- Media extraction and normalization complete within ~4 seconds on mid-range hardware.
+- Download success rate ≥95% for direct media URLs across large batches.
+- No crashes or dead-ends when permissions are denied or network connectivity fluctuates.
+- Comprehensive automated test coverage for all critical utilities and golden UI states.
+
+## Privacy & Compliance Stub
+
+Butter Knife does not include third-party analytics in v1. All network requests are initiated by the user for explicit downloads. Photos/Storage permission prompts explain the need to save media locally. Teams should extend this stub into a full privacy policy before submission.
+
+## [The 17 Commandments of Quality Code]
+
+1. Write code for humans first, machines second.
+2. Choose clarity over cleverness.
+3. Document the why, not just the what.
+4. Be ruthlessly consistent.
+5. Test relentlessly—code without tests is broken by default.
+6. Get every change reviewed by another engineer.
+7. Keep functions and modules small and focused.
+8. Anticipate failure and handle errors gracefully.
+9. Limit the reach of your data.
+10. Leave the code cleaner than you found it.
+11. Name things with purpose and clarity.
+12. Favor simple control flow.
+13. Automate what can be automated.
+14. Be deliberate and sparse with dependencies.
+15. Do not solve problems that do not exist.
+16. Treat all external data as hostile.
+17. Understand the cost of your operations.
+
+
+## Developer Utilities
+
+To derisk the extraction stack we ship a Python toolkit in the `butterknife/` directory. It implements the URL normalization, filtering, probing, and download orchestration used in the mobile app plan. Engineers can exercise the pipeline end-to-end from the command line while Flutter UI work progresses.
+
+### Environment setup
+
+1. `python -m venv .venv`
+2. `source .venv/bin/activate`
+3. `pip install -r requirements-dev.txt`
+
+### Verification commands
+
+- `pytest` — runs the unit and integration-style tests in `tests/`.
+- `ruff check .` — enforces the Python style and catches common issues.
+- `python -m butterknife https://example.com` — prints the structured extraction result for a page.
+- `python -m butterknife https://example.com --download` — downloads all accepted assets into `./downloads`.
+
+Structured logs follow the schema described in the guidance and include the human-readable `[The 17 Commandments of Quality Code]` derived line for traceability.
+
+## Next Steps
+
+1. Stand up the Flutter project scaffold following the feature-first structure described in the engineering plan.
+2. Implement Epic A tickets to solidify dependency injection, models, and the global error surface.
+3. Progress through Epics B–J, validating each slice with the specified acceptance criteria and automated tests.
+4. Prepare store assets, privacy copy, and release notes so the submission package is ready when development completes.
+

--- a/butterknife/__init__.py
+++ b/butterknife/__init__.py
@@ -1,0 +1,13 @@
+"""Butter Knife core extraction utilities."""
+
+from .extractor import extract_from_html, extract_from_url
+from .models import ExtractionResult, MediaItem, MediaType, SkippedStats
+
+__all__ = [
+    "extract_from_html",
+    "extract_from_url",
+    "ExtractionResult",
+    "MediaItem",
+    "MediaType",
+    "SkippedStats",
+]

--- a/butterknife/__main__.py
+++ b/butterknife/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for `python -m butterknife`."""
+
+from .cli import run
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(run())

--- a/butterknife/cli.py
+++ b/butterknife/cli.py
@@ -1,0 +1,100 @@
+"""Command line interface for Butter Knife extraction."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from .extractor import extract_from_url
+from .logger import structured_log
+
+LOGGER = logging.getLogger("butterknife.cli")
+
+
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s %(message)s")
+
+
+def download_media(session: requests.Session, url: str, destination: Path) -> Path:
+    response = session.get(url, stream=True, timeout=30)
+    response.raise_for_status()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("wb") as handle:
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                handle.write(chunk)
+    return destination
+
+
+def run(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Extract media assets from a web page.")
+    parser.add_argument("url", help="Page URL to process")
+    parser.add_argument("--min-bytes", type=int, default=10 * 1024, help="Minimum content length to keep")
+    parser.add_argument("--allow-svg", action="store_true", help="Include SVG images in the results")
+    parser.add_argument("--exclude-gif", action="store_true", help="Filter out animated GIFs")
+    parser.add_argument("--exclude-video", action="store_true", help="Filter out video sources")
+    parser.add_argument("--download", action="store_true", help="Download all found assets")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("downloads"),
+        help="Directory to store downloads when --download is enabled",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+
+    args = parser.parse_args(argv)
+    configure_logging(args.verbose)
+
+    session = requests.Session()
+    result = extract_from_url(
+        args.url,
+        min_bytes=args.min_bytes,
+        allow_svg=args.allow_svg,
+        include_gif=not args.exclude_gif,
+        include_videos=not args.exclude_video,
+        session=session,
+    )
+
+    print(json.dumps(result.to_dict(), indent=2))
+
+    structured_log(
+        LOGGER,
+        logging.INFO,
+        "Extraction complete",
+        system_section="cli",
+        extra={
+            "page_url": args.url,
+            "found": len(result.found),
+            "skipped": result.skipped.as_dict(),
+        },
+    )
+
+    if args.download and result.found:
+        for item in result.found:
+            file_name = item.url.split("/")[-1] or f"asset-{item.id}"
+            destination = args.output / file_name
+            structured_log(
+                LOGGER,
+                logging.INFO,
+                "Downloading media item",
+                system_section="cli.download",
+                method="GET",
+                extra={
+                    "url": item.url,
+                    "destination": str(destination),
+                    "media_type": item.type.value,
+                },
+            )
+            download_media(session, item.url, destination)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(run())

--- a/butterknife/extractor.py
+++ b/butterknife/extractor.py
@@ -1,0 +1,275 @@
+"""High-level extraction pipeline for Butter Knife."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from .filtering import classify_media_type, is_probably_favicon, should_keep
+from .http import ProbeError, probe_url
+from .logger import structured_log
+from .models import ExtractionResult, MediaItem, MediaType
+from .normalization import normalize_candidate
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Candidate:
+    url: str
+    tag: str
+    attributes: Dict[str, str]
+    origin_description: str
+
+
+DEFAULT_MIN_BYTES = 10 * 1024
+
+
+def _pick_best_from_srcset(srcset: str) -> Optional[str]:
+    candidates: List[tuple[float, str]] = []
+    for entry in srcset.split(","):
+        part = entry.strip()
+        if not part:
+            continue
+        segments = part.split()
+        if not segments:
+            continue
+        url = segments[0]
+        descriptor = segments[1] if len(segments) > 1 else "1x"
+        multiplier = 1.0
+        if descriptor.endswith("w"):
+            try:
+                multiplier = float(descriptor[:-1])
+            except ValueError:
+                multiplier = 1.0
+        elif descriptor.endswith("x"):
+            try:
+                multiplier = float(descriptor[:-1])
+            except ValueError:
+                multiplier = 1.0
+        candidates.append((multiplier, url))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def _gather_candidates(soup: BeautifulSoup) -> Iterable[Candidate]:
+    for tag in soup.find_all("img"):
+        attributes = {key: value for key, value in tag.attrs.items() if isinstance(value, str)}
+        srcset = attributes.get("srcset")
+        if srcset:
+            best = _pick_best_from_srcset(srcset)
+            if best:
+                yield Candidate(best, "img", attributes | {"srcset": srcset}, "img[srcset]")
+        src = attributes.get("src")
+        if src:
+            yield Candidate(src, "img", attributes, "img[src]")
+
+    for tag in soup.find_all("source"):
+        attributes = {key: value for key, value in tag.attrs.items() if isinstance(value, str)}
+        src = attributes.get("src")
+        if src:
+            parent = tag.parent.name if tag.parent else "source"
+            yield Candidate(src, parent, attributes, f"{parent}<source>")
+        srcset = attributes.get("srcset")
+        if srcset:
+            best = _pick_best_from_srcset(srcset)
+            if best:
+                parent = tag.parent.name if tag.parent else "source"
+                yield Candidate(best, parent, attributes | {"srcset": srcset}, f"{parent}<source srcset>")
+
+    for tag in soup.find_all("video"):
+        attributes = {key: value for key, value in tag.attrs.items() if isinstance(value, str)}
+        poster = attributes.get("poster")
+        if poster:
+            yield Candidate(poster, "video", attributes, "video[poster]")
+        src = attributes.get("src")
+        if src:
+            yield Candidate(src, "video", attributes, "video[src]")
+
+    for tag in soup.find_all("link"):
+        attributes = {key: value for key, value in tag.attrs.items() if isinstance(value, str)}
+        href = attributes.get("href")
+        if href:
+            yield Candidate(href, "link", attributes, "link[href]")
+
+
+def _candidate_id(normalized_url: str) -> str:
+    return hashlib.sha1(normalized_url.encode("utf-8")).hexdigest()
+
+
+def _is_gif(url: str, content_type: Optional[str]) -> bool:
+    if content_type and content_type.lower().startswith("image/gif"):
+        return True
+    return url.lower().endswith(".gif")
+
+
+def _is_svg(url: str, content_type: Optional[str]) -> bool:
+    if content_type and content_type.lower().endswith("svg+xml"):
+        return True
+    return url.lower().endswith(".svg")
+
+
+def extract_from_html(
+    page_url: str,
+    html: str,
+    *,
+    min_bytes: int = DEFAULT_MIN_BYTES,
+    allow_svg: bool = False,
+    include_gif: bool = True,
+    include_videos: bool = True,
+    session: Optional[requests.Session] = None,
+) -> ExtractionResult:
+    """Extract media items from an HTML payload."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    result = ExtractionResult(page_url=page_url)
+    seen: Dict[str, MediaItem] = {}
+    http_session = session or requests.Session()
+
+    for candidate in _gather_candidates(soup):
+        normalized = normalize_candidate(page_url, candidate.url)
+        if not normalized:
+            structured_log(
+                LOGGER,
+                logging.DEBUG,
+                "Candidate rejected due to unsupported URL scheme",
+                system_section="extraction.filter",
+                extra={"candidate_url": candidate.url},
+            )
+            result.skipped.add(unsupported_scheme=1)
+            continue
+
+        if candidate.tag == "link" and is_probably_favicon(normalized, candidate.attributes):
+            structured_log(
+                LOGGER,
+                logging.DEBUG,
+                "Candidate rejected as favicon",
+                system_section="extraction.filter",
+                extra={"url": normalized},
+            )
+            result.skipped.add(favicons=1)
+            continue
+
+        if normalized in seen:
+            structured_log(
+                LOGGER,
+                logging.DEBUG,
+                "Candidate rejected as duplicate",
+                system_section="extraction.filter",
+                extra={"url": normalized},
+            )
+            result.skipped.add(duplicates=1)
+            continue
+
+        try:
+            probe = probe_url(http_session, normalized)
+        except ProbeError as exc:
+            structured_log(
+                LOGGER,
+                logging.WARNING,
+                "Media probe failed",
+                system_section="extraction.probe",
+                method="HEAD",
+                error=exc,
+                extra={"url": normalized},
+            )
+            result.skipped.add(http_errors=1)
+            continue
+
+        media_type = classify_media_type(probe.url, probe.content_type, candidate.tag)
+        is_svg = _is_svg(probe.url, probe.content_type)
+        is_gif = _is_gif(probe.url, probe.content_type)
+
+        keep = should_keep(
+            media_type,
+            content_length=probe.content_length,
+            min_bytes=min_bytes,
+            allow_svg=allow_svg,
+            is_svg=is_svg,
+            include_gif=include_gif,
+            is_gif=is_gif,
+            include_videos=include_videos,
+        )
+        if not keep:
+            if (
+                media_type is MediaType.IMAGE
+                and probe.content_length is not None
+                and probe.content_length < min_bytes
+            ):
+                result.skipped.add(below_threshold=1)
+                reason = "below_threshold"
+            else:
+                result.skipped.add(unsupported_type=1)
+                reason = "unsupported_type"
+            structured_log(
+                LOGGER,
+                logging.INFO,
+                "Candidate rejected by filter",
+                system_section="extraction.filter",
+                extra={
+                    "url": normalized,
+                    "reason": reason,
+                    "media_type": media_type.value,
+                    "content_length": probe.content_length,
+                },
+            )
+            continue
+
+        item = MediaItem(
+            id=_candidate_id(normalized),
+            type=media_type,
+            url=probe.url,
+            normalized_url=normalized,
+            source_tag=candidate.origin_description,
+            attributes=candidate.attributes,
+            content_length=probe.content_length,
+            content_type=probe.content_type,
+            notes=None,
+        )
+        seen[normalized] = item
+        structured_log(
+            LOGGER,
+            logging.INFO,
+            "Media candidate accepted",
+            system_section="extraction.selection",
+            extra={
+                "url": item.url,
+                "media_type": item.type.value,
+                "content_length": item.content_length,
+            },
+        )
+
+    result.found.extend(seen.values())
+    return result
+
+
+def extract_from_url(
+    page_url: str,
+    *,
+    min_bytes: int = DEFAULT_MIN_BYTES,
+    allow_svg: bool = False,
+    include_gif: bool = True,
+    include_videos: bool = True,
+    session: Optional[requests.Session] = None,
+) -> ExtractionResult:
+    """Fetch a page and extract media items."""
+
+    http_session = session or requests.Session()
+    response = http_session.get(page_url, timeout=10)
+    response.raise_for_status()
+    return extract_from_html(
+        page_url=page_url,
+        html=response.text,
+        min_bytes=min_bytes,
+        allow_svg=allow_svg,
+        include_gif=include_gif,
+        include_videos=include_videos,
+        session=http_session,
+    )

--- a/butterknife/filtering.py
+++ b/butterknife/filtering.py
@@ -1,0 +1,93 @@
+"""Filter rules for Butter Knife media extraction."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Iterable, Optional
+from urllib.parse import urlparse
+
+from .models import MediaType
+
+FAVICON_NAMES = {
+    "favicon.ico",
+    "favicon.png",
+    "apple-touch-icon.png",
+    "apple-touch-icon-precomposed.png",
+}
+
+STREAMING_EXTENSIONS = {".m3u8", ".mpd"}
+VIDEO_EXTENSIONS = {".mp4", ".webm", ".mov", ".m4v", ".avi", ".mpg", ".mpeg"}
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"}
+
+
+def is_probably_favicon(url: str, attributes: Dict[str, str]) -> bool:
+    parsed = urlparse(url)
+    basename = os.path.basename(parsed.path).lower()
+    rel = attributes.get("rel", "").lower()
+    if "icon" in rel or "shortcut" in rel:
+        return True
+    return basename in FAVICON_NAMES
+
+
+def classify_media_type(url: str, content_type: Optional[str], tag_name: str) -> MediaType:
+    if content_type:
+        lower = content_type.lower()
+        if lower.startswith("image/"):
+            return MediaType.IMAGE
+        if lower.startswith("video/"):
+            return MediaType.VIDEO
+        if lower in {"application/vnd.apple.mpegurl", "application/dash+xml"}:
+            return MediaType.STREAMING
+
+    parsed = urlparse(url)
+    ext = os.path.splitext(parsed.path)[1].lower()
+    if ext in STREAMING_EXTENSIONS:
+        return MediaType.STREAMING
+    if ext in VIDEO_EXTENSIONS:
+        return MediaType.VIDEO
+    if ext in IMAGE_EXTENSIONS:
+        return MediaType.IMAGE
+    if tag_name == "video":
+        return MediaType.VIDEO
+    return MediaType.UNKNOWN
+
+
+def should_keep(
+    media_type: MediaType,
+    *,
+    content_length: Optional[int],
+    min_bytes: int,
+    allow_svg: bool,
+    is_svg: bool,
+    include_gif: bool,
+    is_gif: bool,
+    include_videos: bool,
+) -> bool:
+    if media_type is MediaType.STREAMING:
+        return False
+
+    if media_type is MediaType.VIDEO:
+        return include_videos
+
+    if media_type is MediaType.IMAGE:
+        if not allow_svg and is_svg:
+            return False
+        if not include_gif and is_gif:
+            return False
+        if content_length is not None and content_length < min_bytes:
+            return False
+        return True
+
+    if media_type is MediaType.UNKNOWN:
+        if content_length is not None and content_length >= min_bytes:
+            return True
+        return False
+
+    return False
+
+
+def summarize_types(items: Iterable[MediaType]) -> Dict[MediaType, int]:
+    summary: Dict[MediaType, int] = {}
+    for item_type in items:
+        summary[item_type] = summary.get(item_type, 0) + 1
+    return summary

--- a/butterknife/http.py
+++ b/butterknife/http.py
@@ -1,0 +1,100 @@
+"""Networking helpers for probing media metadata."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+
+from .logger import structured_log
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ProbeResult:
+    url: str
+    content_type: Optional[str]
+    content_length: Optional[int]
+
+
+class ProbeError(RuntimeError):
+    """Raised when a probe fails permanently."""
+
+
+DEFAULT_TIMEOUT = 10
+
+
+def _safe_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def probe_url(
+    session: requests.Session,
+    url: str,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> ProbeResult:
+    """Fetch metadata for a media URL using HEAD with GET fallback."""
+
+    headers = {"User-Agent": "ButterKnife/1.0"}
+    try:
+        response = session.head(url, allow_redirects=True, timeout=timeout, headers=headers)
+    except requests.RequestException as exc:
+        structured_log(
+            LOGGER,
+            logging.DEBUG,
+            "HEAD probe failed",
+            system_section="network.probe",
+            method="HEAD",
+            error=exc,
+            extra={"url": url},
+        )
+        response = None
+
+    if response is None or response.status_code >= 400:
+        try:
+            response = session.get(
+                url,
+                allow_redirects=True,
+                timeout=timeout,
+                headers={**headers, "Range": "bytes=0-0"},
+            )
+        except requests.RequestException as exc:
+            structured_log(
+                LOGGER,
+                logging.DEBUG,
+                "GET probe failed",
+                system_section="network.probe",
+                method="GET",
+                error=exc,
+                extra={"url": url},
+            )
+            raise ProbeError(str(exc)) from exc
+
+    if response is None:
+        raise ProbeError("No response during probe")
+
+    content_type = response.headers.get("Content-Type")
+    content_length = _safe_int(response.headers.get("Content-Length"))
+
+    structured_log(
+        LOGGER,
+        logging.DEBUG,
+        "Probe succeeded",
+        system_section="network.probe",
+        method="HEAD" if response.request.method == "HEAD" else "GET",
+        extra={
+            "url": response.url or url,
+            "content_type": content_type,
+            "content_length": content_length,
+        },
+    )
+
+    return ProbeResult(url=response.url or url, content_type=content_type, content_length=content_length)

--- a/butterknife/logger.py
+++ b/butterknife/logger.py
@@ -1,0 +1,56 @@
+"""Structured logging utilities for Butter Knife."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def structured_log(
+    logger: logging.Logger,
+    level: int,
+    message: str,
+    *,
+    system_section: str,
+    method: str = "NONE",
+    error: Optional[BaseException] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    frame = inspect.currentframe()
+    try:
+        if frame is None or frame.f_back is None:
+            caller = None
+        else:
+            caller = frame.f_back
+
+        filename = Path(caller.f_code.co_filename).name if caller else "<unknown>"
+        function = caller.f_code.co_name if caller else "<unknown>"
+        line_num = caller.f_lineno if caller else 0
+        classname = caller.f_globals.get("__name__", "<module>") if caller else "<module>"
+
+        payload: Dict[str, Any] = {
+            "filename": filename,
+            "timestamp": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+            "classname": classname,
+            "function": function,
+            "system_section": system_section,
+            "line_num": line_num,
+            "error": str(error) if error else None,
+            "db_phase": "none",
+            "method": method,
+            "message": message,
+        }
+        if extra:
+            payload.update(extra)
+
+        logger.log(level, json.dumps(payload, ensure_ascii=False))
+        derived = f"[The 17 Commandments of Quality Code] {message}"
+        logger.log(level, derived)
+    finally:
+        del frame
+        if 'caller' in locals():
+            del caller

--- a/butterknife/models.py
+++ b/butterknife/models.py
@@ -1,0 +1,79 @@
+"""Data structures for Butter Knife media extraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class MediaType(str, Enum):
+    """Canonical media types discovered on a page."""
+
+    IMAGE = "image"
+    VIDEO = "video"
+    STREAMING = "streaming"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class MediaItem:
+    """A single downloadable media candidate."""
+
+    id: str
+    type: MediaType
+    url: str
+    normalized_url: str
+    source_tag: str
+    attributes: Dict[str, str] = field(default_factory=dict)
+    content_length: Optional[int] = None
+    content_type: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    thumbnail_url: Optional[str] = None
+    notes: Optional[str] = None
+
+
+@dataclass
+class SkippedStats:
+    """Diagnostics for why candidates were skipped."""
+
+    favicons: int = 0
+    below_threshold: int = 0
+    unsupported_scheme: int = 0
+    duplicates: int = 0
+    unsupported_type: int = 0
+    http_errors: int = 0
+
+    def as_dict(self) -> Dict[str, int]:
+        return {
+            "favicons": self.favicons,
+            "below_threshold": self.below_threshold,
+            "unsupported_scheme": self.unsupported_scheme,
+            "duplicates": self.duplicates,
+            "unsupported_type": self.unsupported_type,
+            "http_errors": self.http_errors,
+        }
+
+    def add(self, **kwargs: int) -> None:
+        for key, value in kwargs.items():
+            if not hasattr(self, key):
+                raise AttributeError(f"Unknown skip reason: {key}")
+            current = getattr(self, key)
+            setattr(self, key, current + int(value))
+
+
+@dataclass
+class ExtractionResult:
+    """Full result from scanning a page."""
+
+    page_url: str
+    found: List[MediaItem] = field(default_factory=list)
+    skipped: SkippedStats = field(default_factory=SkippedStats)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "page_url": self.page_url,
+            "found": [item.__dict__ for item in self.found],
+            "skipped": self.skipped.as_dict(),
+        }

--- a/butterknife/normalization.py
+++ b/butterknife/normalization.py
@@ -1,0 +1,31 @@
+"""URL normalization utilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+from urllib.parse import ParseResult, parse_qsl, urljoin, urlparse, urlunparse, urlencode
+
+
+def _sorted_query(parsed: ParseResult) -> str:
+    query_items = parse_qsl(parsed.query, keep_blank_values=True)
+    if not query_items:
+        return ""
+    return urlencode(sorted(query_items), doseq=True)
+
+
+def normalize_candidate(page_url: str, candidate_url: str) -> Optional[str]:
+    """Resolve and normalize a candidate media URL."""
+
+    candidate_url = candidate_url.strip()
+    if not candidate_url:
+        return None
+    if candidate_url.startswith("data:") or candidate_url.startswith("blob:"):
+        return None
+
+    resolved = urljoin(page_url, candidate_url)
+    parsed = urlparse(resolved)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+
+    normalized = parsed._replace(fragment="", query=_sorted_query(parsed))
+    return urlunparse(normalized)

--- a/docs/ENGINEERING_PLAN.md
+++ b/docs/ENGINEERING_PLAN.md
@@ -1,0 +1,163 @@
+# Butter Knife — Engineering Plan
+
+The following senior-level plan organizes the work required to ship the Butter Knife production application on Flutter with GetX, Dio, and supporting libraries. Each ticket includes a clear acceptance bar so work can be tracked in Jira or Linear.
+
+## Epic A — Core Architecture & State
+
+### A1. App scaffolding and DI
+- Create feature-first structure: `features/{browser,extract,gallery,download}/…`, `core/{network,storage,util}/…`.
+- Wire GetX bindings for controllers: `BrowserController`, `ExtractionController`, `DownloadController`, `SettingsController`.
+- Define sealed result types and app-wide error model.
+- **Acceptance:** App builds and runs. Controllers injectable via bindings; global error model usable across layers.
+
+### A2. Models & serialization
+- Define `MediaItem { id, type(image|video), url, normalizedUrl, width?, height?, bytes?, contentLength?, thumbnailUrl?, isSelected }`.
+- Define `ExtractionResult { pageUrl, found: List<MediaItem>, skipped: SkippedStats }`.
+- Add JSON serialization and equality.
+- **Acceptance:** Round-trip tests pass; equality works for dedupe.
+
+## Epic B — WebView + Page Pipeline
+
+### B1. WebView screen with URL bar
+- Implement a URL entry screen with validation and an **Open in WebView** action.
+- Use `webview_flutter` with custom user-agent toggle.
+- **Acceptance:** User can open arbitrary pages; navigation controls (back/forward/reload) work.
+
+### B2. JS bridge for DOM extraction
+- Inject JS to collect:
+  - `<img src/srcset>` best candidate URLs
+  - `<source>` under `<picture>`
+  - `<video poster>` and `<video><source src>` URLs
+  - Filter obvious favicon links via `<link rel="icon">` and common paths.
+- Send extracted candidates through `JavascriptChannel` back to Flutter.
+- **Acceptance:** For a test page, bridge returns arrays of candidate URLs with element tag and attributes.
+
+### B3. Process overlay
+- Add full-screen overlay with progress states: `Scanning DOM → Normalizing URLs → Probing sizes → Building grid`.
+- **Acceptance:** Overlay appears during processing and hides on completion or error.
+
+## Epic C — URL Normalization, Probing, and Filtering
+
+### C1. URL normalization & de-duplication
+- Resolve relative URLs against page URL, strip fragments, sort query keys for canonical comparison.
+- De-duplicate by normalized URL.
+- **Acceptance:** Unit tests cover relative paths, query noise, and duplication.
+
+### C2. Content probing (HEAD/GET)
+- Use Dio to fetch `Content-Type` and `Content-Length` with HEAD; fall back to lightweight GET on servers that block HEAD.
+- Classify as `image/*` or `video/*`.
+- Handle `data:` and `blob:` URLs (skip or attempt fallback snapshot if feasible).
+- **Acceptance:** Items include `contentLength` and `type`. Unknown or streaming types are flagged.
+
+### C3. Filter rules
+- Exclude:
+  - Favicons by rel/type and common file names (`/favicon.ico`, `apple-touch-icon*`).
+  - Images where `contentLength < 10 KB`.
+- Keep: images (jpg/png/webp/gif/svg*) and videos (mp4/webm/mov*) with known content length or direct file URL.
+- Mark HLS/DASH (`.m3u8`, `.mpd`) as **streaming** and not downloadable in v1.
+- **Acceptance:** Test fixture verifies correct keep/skip decisions.
+
+## Epic D — UI: Grid, Selection, and Details
+
+### D1. Grid gallery
+- Lazy grid with thumbnails. Use network thumbnails; for videos show play overlay icon.
+- Quick select/deselect; counter of selected items; **Download All** button.
+- **Acceptance:** Stable 60fps on 50–200 items; selection state persists while navigating.
+
+### D2. Item details sheet
+- Bottom sheet: preview, file type, approximate size, source tag, open in browser.
+- **Acceptance:** Tapping tile opens sheet; links work.
+
+### D3. Empty/error states
+- Empty state with suggestions (try another page).
+- Error state with retry.
+- **Acceptance:** Visuals meet design spec.
+
+## Epic E — Download Manager
+
+### E1. Download orchestration
+- Implement a queued download manager with concurrency limit (default 3), retry policy (e.g., 2 retries, exponential backoff), pause/cancel.
+- Per-item progress and overall progress.
+- **Acceptance:** Can download 20–100 items reliably with progress and cancellation.
+
+### E2. Background downloads (Android)
+- Integrate `flutter_downloader` or keep foreground with `WorkManager` fallback.
+- Persist queue across app restarts.
+- **Acceptance:** Kill app mid-download; queue resumes automatically on reopen.
+
+### E3. Save destinations
+- Android: MediaStore (Pictures/ButterKnife and Movies/ButterKnife), handle scoped storage on Android 10+.
+- iOS: Save to Photos album (Butter Knife).
+- Optional setting: save to app documents instead of gallery.
+- **Acceptance:** Files visible in Photos/Gallery; album created if missing.
+
+## Epic F — Permissions & Platform Integration
+
+### F1. Runtime permissions
+- Android: manage `READ_MEDIA_IMAGES/VIDEO` (Android 13+), legacy fallback with `WRITE_EXTERNAL_STORAGE` if required on older versions.
+- iOS: request `PHPhotoLibraryAddOnly` permission and add Info.plist strings.
+- **Acceptance:** Permission flows are clear, localized, and handled gracefully if denied.
+
+### F2. App settings deep links
+- Provide "Open Settings" when permission is permanently denied.
+- **Acceptance:** Works on Android and iOS.
+
+## Epic G — Settings & Preferences
+
+### G1. Settings screen
+- Toggle: minimum image size (default 10 KB), user-agent (mobile/desktop), concurrency, include SVG, include GIF/video autoplay thumbnails.
+- **Acceptance:** Settings persist via `shared_preferences` and apply on next run.
+
+## Epic H — Logging, Telemetry, and Privacy
+
+### H1. Local activity log
+- Local ring buffer log for debugging (no PII, no external telemetry). Export log as text for support.
+- **Acceptance:** Log captures page URL host, counts, durations, and errors without storing content.
+
+### H2. Privacy review
+- Confirm no third-party analytics for v1. Document data handling in a privacy policy stub.
+- **Acceptance:** Policy text prepared for store submission.
+
+## Epic I — Testing & QA
+
+### I1. Unit tests
+- URL normalization, filter logic, content-type classification, HEAD fallback logic.
+- **Acceptance:** ≥90% coverage for core utilities.
+
+### I2. Integration tests
+- Happy path on a controlled local HTML fixture.
+- Large page stress test (200+ media items).
+- Permission denial and recovery.
+- **Acceptance:** All tests pass in CI.
+
+### I3. Golden tests
+- Grid view (empty, partial, full), error screens.
+- **Acceptance:** Golden diffs stable across platforms.
+
+## Epic J — Store Readiness
+
+### J1. App icons, branding, and screenshots
+- Generate adaptive icons and iOS asset catalog.
+- Capture screenshots that show URL entry, WebView, processing overlay, grid, and downloads.
+- **Acceptance:** Assets meet Play/App Store requirements.
+
+### J2. Store metadata
+- Finalize description, keywords, privacy labels, and permission rationale.
+- **Acceptance:** Metadata files ready for submission.
+
+## Implementation Notes (Senior Pointers)
+- Packages: `webview_flutter`, `dio`, `html`, `get`, `path_provider`, `permission_handler`, `flutter_downloader` (Android), `photo_manager` or platform save helpers for iOS, `cached_network_image` for grid thumbs.
+- Performance: Use `compute` or isolates to parse HTML and to run HEAD probes on a throttled pool. Batch HEADs (e.g., 10 at a time) to avoid rate-limits.
+- Favicons: Exclude via DOM rel checks and filename heuristics, then fall back to size threshold.
+- Videos: Ship v1 with direct file URLs only (`.mp4`, `.webm`, `.mov`). Mark HLS/DASH as **Streaming** and do not download in v1.
+- Resilience: Some sites block HEAD; fall back to ranged GET with `Range: bytes=0-0` to infer content type when safe.
+- Storage: On Android 10+, prefer MediaStore insert with `RELATIVE_PATH`. On iOS, use `PHPhotoLibrary` via plugin to create album and save.
+- Legal: Add a warning dialog on first run to respect copyrights and site terms.
+
+## Definitions of Done (DoD) Summary
+- Processes a real-world page with mixed media and returns a deduplicated grid in under ~4 seconds on a mid-range device.
+- Correctly excludes favicons and images under the size threshold.
+- Downloads succeed for at least 95% of direct image/video URLs across a 100-item batch.
+- All critical paths covered by tests; no crashes on permission denials or network loss.
+- Store metadata and privacy text are complete and accurate.
+

--- a/docs/STORE_DESCRIPTION.md
+++ b/docs/STORE_DESCRIPTION.md
@@ -1,0 +1,43 @@
+# Butter Knife — Store-Ready Copy
+
+## Name
+
+**Butter Knife — Bulk Image & Video Saver**
+
+## Short Description
+
+Collect images and videos from any web page. Preview, pick, and save.
+
+## Subtitle (iOS)
+
+Bulk media downloader
+
+## Full Description
+
+**Butter Knife** makes it simple to collect images and videos from any web page in seconds. Paste a URL or open the page in the built-in WebView, tap **Process**, and Butter Knife scans the page to find media. Images smaller than **10 KB** are skipped and common **favicons are excluded**, so you see only useful assets. Preview everything in a clean grid, then **Download All** or save items individually.
+
+### Key Features
+
+* **One-tap processing:** Paste a URL or browse in the app. An on-screen overlay shows **Processing…** while Butter Knife scans the page.
+* **Smart filtering:** Excludes favicons and images smaller than **10 KB**.
+* **Video support:** Detects direct video links and `<video>` sources when available.
+* **Grid preview:** See all found media at a glance, with quick selection.
+* **Flexible saving:** **Download All** or tap any item to save individually.
+* **Fast repeat:** Go back at any time to process another page.
+
+### How It Works
+
+1. Enter or paste a web page URL, or open the page in the in-app WebView.
+2. Tap **Process**. A processing overlay appears while the app scans the page.
+3. After processing, qualifying images and videos are shown in a grid.
+4. Tap **Download All**, or save items one by one.
+5. Return to the start screen to process another page.
+
+### Permissions
+
+* **Photos/Storage:** Required to save downloaded media to your device.
+
+### Notes
+
+* Please respect website terms and copyrights when downloading content.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "butterknife-toolkit"
+version = "0.1.0"
+description = "Media extraction utilities for Butter Knife"
+requires-python = ">=3.11"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-q"
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest==7.4.4
+responses==0.25.0
+ruff==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4==4.12.3
+requests==2.31.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/fixtures/sample.html
+++ b/tests/fixtures/sample.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sample</title>
+    <link rel="icon" href="/favicon.ico" />
+  </head>
+  <body>
+    <main>
+      <img src="/images/logo.png" alt="Logo" />
+      <img
+        src="/images/hero-small.jpg"
+        srcset="/images/hero-large.jpg 2x, /images/hero-small.jpg 1x"
+        alt="Hero"
+      />
+      <video controls poster="/images/poster.jpg">
+        <source src="/video/promo.mp4" type="video/mp4" />
+      </video>
+    </main>
+  </body>
+</html>

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import responses
+
+from butterknife.extractor import extract_from_html
+from butterknife.models import MediaType
+
+FIXTURE_HTML = (
+    Path(__file__).parent / "fixtures" / "sample.html"
+).read_text()
+
+
+def add_head(url: str, length: int, content_type: str) -> None:
+    responses.add(
+        responses.HEAD,
+        url,
+        body=b'0' * length,
+        headers={"Content-Type": content_type, "Content-Length": str(length)},
+    )
+
+
+@responses.activate
+def test_extract_from_html_filters_favicons_and_small_assets():
+    page_url = "https://example.com/article"
+
+    add_head("https://example.com/images/hero-large.jpg", 20480, "image/jpeg")
+    add_head("https://example.com/images/logo.png", 1024, "image/png")
+    add_head("https://example.com/images/hero-small.jpg", 5120, "image/jpeg")
+    add_head("https://example.com/video/promo.mp4", 51200, "video/mp4")
+    add_head("https://example.com/images/poster.jpg", 15360, "image/jpeg")
+
+    result = extract_from_html(
+        page_url,
+        FIXTURE_HTML,
+    )
+
+    assert len(result.found) == 3
+    media_types = {item.type for item in result.found}
+    assert MediaType.IMAGE in media_types
+    assert MediaType.VIDEO in media_types
+
+    favicon_count = result.skipped.favicons
+    below_threshold = result.skipped.below_threshold
+    assert favicon_count == 1
+    assert below_threshold == 2
+
+
+@responses.activate
+def test_extract_from_html_handles_probe_errors(caplog):
+    page_url = "https://example.com/article"
+
+    responses.add(
+        responses.HEAD,
+        "https://example.com/images/hero-large.jpg",
+        body=responses.ConnectionError("boom"),
+    )
+    add_head("https://example.com/images/logo.png", 1024, "image/png")
+    add_head("https://example.com/images/hero-small.jpg", 5120, "image/jpeg")
+    add_head("https://example.com/video/promo.mp4", 51200, "video/mp4")
+    add_head("https://example.com/images/poster.jpg", 15360, "image/jpeg")
+
+    result = extract_from_html(
+        page_url,
+        FIXTURE_HTML,
+    )
+
+    assert len(result.found) == 2
+    assert all("hero-large" not in item.url for item in result.found)
+    assert result.skipped.http_errors == 1
+    assert any("Media probe failed" in message for message in caplog.messages)
+
+
+@responses.activate
+def test_extract_from_html_head_fallback_to_get():
+    page_url = "https://example.com/article"
+
+    responses.add(
+        responses.HEAD,
+        "https://example.com/images/hero-large.jpg",
+        status=405,
+    )
+    responses.add(
+        responses.GET,
+        "https://example.com/images/hero-large.jpg",
+        body=b'0' * 20480,
+        headers={"Content-Type": "image/jpeg", "Content-Length": "20480"},
+    )
+    add_head("https://example.com/images/logo.png", 1024, "image/png")
+    add_head("https://example.com/images/hero-small.jpg", 5120, "image/jpeg")
+    add_head("https://example.com/video/promo.mp4", 51200, "video/mp4")
+    add_head("https://example.com/images/poster.jpg", 15360, "image/jpeg")
+
+    result = extract_from_html(
+        page_url,
+        FIXTURE_HTML,
+    )
+
+    assert len(result.found) == 3

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,45 @@
+from butterknife.filtering import (
+    classify_media_type,
+    is_probably_favicon,
+    should_keep,
+)
+from butterknife.models import MediaType
+
+
+def test_is_probably_favicon_by_rel():
+    url = "https://example.com/icon.png"
+    attributes = {"rel": "shortcut icon"}
+    assert is_probably_favicon(url, attributes)
+
+
+def test_classify_media_type_prefers_content_type():
+    media_type = classify_media_type("https://example.com/video.mp4", "video/mp4", "video")
+    assert media_type is MediaType.VIDEO
+
+
+def test_should_keep_filters_small_images():
+    keep = should_keep(
+        MediaType.IMAGE,
+        content_length=5000,
+        min_bytes=10_000,
+        allow_svg=False,
+        is_svg=False,
+        include_gif=True,
+        is_gif=False,
+        include_videos=True,
+    )
+    assert not keep
+
+
+def test_should_keep_allows_large_images():
+    keep = should_keep(
+        MediaType.IMAGE,
+        content_length=50_000,
+        min_bytes=10_000,
+        allow_svg=False,
+        is_svg=False,
+        include_gif=True,
+        is_gif=False,
+        include_videos=True,
+    )
+    assert keep

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,21 @@
+from butterknife.normalization import normalize_candidate
+
+
+def test_normalize_candidate_resolves_relative_url():
+    page = "https://example.com/articles/index.html"
+    candidate = "../images/photo.jpg"
+    normalized = normalize_candidate(page, candidate)
+    assert normalized == "https://example.com/images/photo.jpg"
+
+
+def test_normalize_candidate_sorts_query_parameters():
+    page = "https://example.com/"
+    candidate = "https://example.com/image.jpg?b=2&a=1"
+    normalized = normalize_candidate(page, candidate)
+    assert normalized == "https://example.com/image.jpg?a=1&b=2"
+
+
+def test_normalize_candidate_rejects_data_urls():
+    page = "https://example.com/"
+    candidate = "data:image/png;base64,AAAA"
+    assert normalize_candidate(page, candidate) is None


### PR DESCRIPTION
## Summary
- add a Python implementation of the media extraction pipeline including models, normalization, filtering, HTTP probing, and structured logging
- provide a command-line interface with download support and document setup commands for the toolkit
- introduce automated tests, fixtures, dependency pins, and gitignore rules to keep bytecode out of version control

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68cf799cc600832b90ab91f5d3d8fb2b