### PR TITLE
Add Flutter application scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ Butter Knife does not include third-party analytics in v1. All network requests 
 17. Understand the cost of your operations.
 
 
+
+## Flutter Application
+
+The Flutter implementation lives in [`mobile/`](mobile/). It follows the feature-first structure outlined in the engineering plan with GetX bindings, typed models, WebView-driven extraction, and a basic gallery panel.
+
+### Running the app
+
+1. Install the Flutter stable SDK (3.22 or newer).
+2. From the `mobile/` directory run `flutter pub get`.
+3. Launch the application with `flutter run`.
+
+### Verification commands
+
+- `flutter test` — validates the Dart models, URI helpers, and settings state.
+- `flutter analyze` — lints the Flutter codebase using `flutter_lints`.
+
+The mobile logs use the structured schema described above and emit the `[The 17 Commandments of Quality Code]` derived line so traceability is consistent across platforms.
+
 ## Developer Utilities
 
 To derisk the extraction stack we ship a Python toolkit in the `butterknife/` directory. It implements the URL normalization, filtering, probing, and download orchestration used in the mobile app plan. Engineers can exercise the pipeline end-to-end from the command line while Flutter UI work progresses.

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,8 @@
+# Flutter build outputs
+build/
+.dart_tool/
+.packages
+.flutter-plugins
+.flutter-plugins-dependencies
+.melos_tool
+generated_plugin_registrant.dart

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,19 @@
+# Butter Knife Flutter Application
+
+This directory hosts the Butter Knife Flutter app. The project adopts a feature-first layout with shared core utilities.
+
+## Structure
+
+- `lib/`
+  - `core/` — bindings, logging, error modeling, networking, persistence helpers.
+  - `features/` — feature domains (`browser`, `extract`, `download`, `settings`).
+  - `shared/` — cross-cutting models such as `MediaItem` and `ExtractionResult`.
+- `test/` — unit tests covering serialization, URI normalization, and settings state.
+
+## Getting Started
+
+1. Install Flutter 3.22 or newer.
+2. Run `flutter pub get` inside this directory.
+3. Launch the application with `flutter run` or execute `flutter test` for unit coverage.
+
+Logs conform to the structured schema defined at the repository root and emit the `[The 17 Commandments of Quality Code]` tag for parity with the Python toolkit.

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -1,0 +1,14 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-raw-types: true
+  errors:
+    missing_required_param: error
+    missing_return: error
+
+linter:
+  rules:
+    prefer_single_quotes: true
+    always_use_package_imports: true

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'core/bindings/app_bindings.dart';
+import 'core/logging/app_logger.dart';
+import 'features/browser/views/browser_view.dart';
+
+class ButterKnifeApp extends StatelessWidget {
+  const ButterKnifeApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    AppLogger.logInfo(
+      filename: 'lib/app.dart',
+      classname: 'ButterKnifeApp',
+      function: 'build',
+      systemSection: 'ui',
+      message: 'Building root application widget',
+    );
+    return GetMaterialApp(
+      title: 'Butter Knife',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.amber),
+        useMaterial3: true,
+      ),
+      initialBinding: AppBindings(),
+      home: const BrowserView(),
+    );
+  }
+}

--- a/mobile/lib/core/bindings/app_bindings.dart
+++ b/mobile/lib/core/bindings/app_bindings.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:get/get.dart';
+
+import '../network/dio_client.dart';
+import '../storage/settings_storage.dart';
+import '../../features/browser/controllers/browser_controller.dart';
+import '../../features/download/controllers/download_controller.dart';
+import '../../features/extract/controllers/extraction_controller.dart';
+import '../../features/settings/controllers/settings_controller.dart';
+
+class AppBindings extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<Dio>(() => const DioClientFactory().create(), fenix: true);
+
+    Get.putAsync<SettingsController>(() async {
+      final storage = await const SettingsStorageFactory().create();
+      final controller = SettingsController(storage);
+      return controller;
+    }, permanent: true);
+
+    Get.lazyPut<ExtractionController>(
+      () => ExtractionController(Get.find<Dio>()),
+      fenix: true,
+    );
+    Get.lazyPut<DownloadController>(
+      () => DownloadController(Get.find<Dio>()),
+      fenix: true,
+    );
+    Get.lazyPut<BrowserController>(
+      () => BrowserController(Get.find<ExtractionController>()),
+      fenix: true,
+    );
+  }
+}

--- a/mobile/lib/core/errors/app_error.dart
+++ b/mobile/lib/core/errors/app_error.dart
@@ -1,0 +1,56 @@
+sealed class AppError implements Exception {
+  const AppError(this.message, [this.stackTrace]);
+
+  final String message;
+  final StackTrace? stackTrace;
+
+  Map<String, dynamic> toJson();
+
+  @override
+  String toString() => message;
+}
+
+final class NetworkError extends AppError {
+  const NetworkError(String message, {this.statusCode, StackTrace? stackTrace})
+      : super(message, stackTrace);
+
+  final int? statusCode;
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'type': 'network',
+        'message': message,
+        'statusCode': statusCode,
+        'stackTrace': stackTrace?.toString(),
+      };
+}
+
+final class ValidationError extends AppError {
+  const ValidationError(String message, {StackTrace? stackTrace})
+      : super(message, stackTrace);
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'type': 'validation',
+        'message': message,
+        'stackTrace': stackTrace?.toString(),
+      };
+}
+
+final class UnknownError extends AppError {
+  const UnknownError(String message, {Object? cause, StackTrace? stackTrace})
+      : _cause = cause,
+        super(message, stackTrace);
+
+  final Object? _cause;
+
+  Object? get cause => _cause;
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'type': 'unknown',
+        'message': message,
+        'cause': _cause?.toString(),
+        'stackTrace': stackTrace?.toString(),
+      };
+}

--- a/mobile/lib/core/logging/app_logger.dart
+++ b/mobile/lib/core/logging/app_logger.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+class AppLogger {
+  static const _derivedTag = '[The 17 Commandments of Quality Code]';
+
+  const AppLogger._();
+
+  static void logDebug({
+    required String filename,
+    required String classname,
+    required String function,
+    required String systemSection,
+    required String message,
+    int? lineNumber,
+    String method = 'NONE',
+    String dbPhase = 'none',
+  }) {
+    _log(
+      level: 'DEBUG',
+      filename: filename,
+      classname: classname,
+      function: function,
+      systemSection: systemSection,
+      message: message,
+      lineNumber: lineNumber,
+      method: method,
+      dbPhase: dbPhase,
+    );
+  }
+
+  static void logInfo({
+    required String filename,
+    required String classname,
+    required String function,
+    required String systemSection,
+    required String message,
+    int? lineNumber,
+    String method = 'NONE',
+    String dbPhase = 'none',
+  }) {
+    _log(
+      level: 'INFO',
+      filename: filename,
+      classname: classname,
+      function: function,
+      systemSection: systemSection,
+      message: message,
+      lineNumber: lineNumber,
+      method: method,
+      dbPhase: dbPhase,
+    );
+  }
+
+  static void logError({
+    required String filename,
+    required String classname,
+    required String function,
+    required String systemSection,
+    required String message,
+    Object? error,
+    StackTrace? stackTrace,
+    int? lineNumber,
+    String method = 'NONE',
+    String dbPhase = 'none',
+  }) {
+    _log(
+      level: 'ERROR',
+      filename: filename,
+      classname: classname,
+      function: function,
+      systemSection: systemSection,
+      message: message,
+      error: error?.toString(),
+      stackTrace: stackTrace?.toString(),
+      lineNumber: lineNumber,
+      method: method,
+      dbPhase: dbPhase,
+    );
+  }
+
+  static void _log({
+    required String level,
+    required String filename,
+    required String classname,
+    required String function,
+    required String systemSection,
+    required String message,
+    String? error,
+    String? stackTrace,
+    int? lineNumber,
+    String method = 'NONE',
+    String dbPhase = 'none',
+  }) {
+    final payload = <String, dynamic>{
+      'level': level,
+      'filename': filename,
+      'timestamp': DateTime.now().toUtc().toIso8601String(),
+      'classname': classname,
+      'function': function,
+      'system_section': systemSection,
+      'line_num': lineNumber,
+      'error': error,
+      'stack_trace': stackTrace,
+      'db_phase': dbPhase,
+      'method': method,
+      'message': message,
+    };
+
+    debugPrint(jsonEncode(payload));
+    debugPrint('$_derivedTag $message');
+  }
+}

--- a/mobile/lib/core/network/dio_client.dart
+++ b/mobile/lib/core/network/dio_client.dart
@@ -1,0 +1,66 @@
+import 'package:dio/dio.dart';
+
+import '../logging/app_logger.dart';
+
+class DioClientFactory {
+  const DioClientFactory();
+
+  Dio create() {
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+        sendTimeout: const Duration(seconds: 10),
+        headers: {
+          'User-Agent':
+              'ButterKnife/0.1 (+https://github.com/butterknife-mobile) Flutter',
+        },
+      ),
+    );
+
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          AppLogger.logDebug(
+            filename: 'lib/core/network/dio_client.dart',
+            classname: 'DioClientFactory',
+            function: 'onRequest',
+            systemSection: 'network',
+            message: 'HTTP ${options.method} ${options.uri}',
+            method: options.method,
+          );
+          handler.next(options);
+        },
+        onResponse: (response, handler) {
+          AppLogger.logDebug(
+            filename: 'lib/core/network/dio_client.dart',
+            classname: 'DioClientFactory',
+            function: 'onResponse',
+            systemSection: 'network',
+            message:
+                'HTTP ${response.requestOptions.method} ${response.requestOptions.uri} => ${response.statusCode}',
+            method: response.requestOptions.method,
+            dbPhase: 'none',
+          );
+          handler.next(response);
+        },
+        onError: (error, handler) {
+          AppLogger.logError(
+            filename: 'lib/core/network/dio_client.dart',
+            classname: 'DioClientFactory',
+            function: 'onError',
+            systemSection: 'network',
+            message:
+                'HTTP ${error.requestOptions.method} ${error.requestOptions.uri} failed',
+            error: error,
+            stackTrace: error.stackTrace,
+            method: error.requestOptions.method,
+          );
+          handler.next(error);
+        },
+      ),
+    );
+
+    return dio;
+  }
+}

--- a/mobile/lib/core/result/app_result.dart
+++ b/mobile/lib/core/result/app_result.dart
@@ -1,0 +1,30 @@
+import '../errors/app_error.dart';
+
+sealed class AppResult<T> {
+  const AppResult();
+
+  bool get isSuccess => this is AppSuccess<T>;
+  bool get isFailure => this is AppFailure<T>;
+
+  R when<R>({
+    required R Function(T value) success,
+    required R Function(AppError error) failure,
+  }) {
+    if (this is AppSuccess<T>) {
+      return success((this as AppSuccess<T>).value);
+    }
+    return failure((this as AppFailure<T>).error);
+  }
+}
+
+final class AppSuccess<T> extends AppResult<T> {
+  const AppSuccess(this.value);
+
+  final T value;
+}
+
+final class AppFailure<T> extends AppResult<T> {
+  const AppFailure(this.error);
+
+  final AppError error;
+}

--- a/mobile/lib/core/storage/settings_storage.dart
+++ b/mobile/lib/core/storage/settings_storage.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../logging/app_logger.dart';
+import '../../features/settings/models/settings_state.dart';
+
+abstract class SettingsStorage {
+  Future<SettingsState?> load();
+  Future<void> save(SettingsState state);
+}
+
+class SharedPreferencesSettingsStorage implements SettingsStorage {
+  SharedPreferencesSettingsStorage(this._preferences);
+
+  final SharedPreferences _preferences;
+
+  static const _key = 'butterknife_settings';
+
+  @override
+  Future<SettingsState?> load() async {
+    final jsonString = _preferences.getString(_key);
+    if (jsonString == null) {
+      return null;
+    }
+    final decoded = jsonDecode(jsonString) as Map<String, dynamic>;
+    return SettingsState.fromJson(decoded);
+  }
+
+  @override
+  Future<void> save(SettingsState state) async {
+    await _preferences.setString(_key, jsonEncode(state.toJson()));
+  }
+}
+
+class InMemorySettingsStorage implements SettingsStorage {
+  SettingsState? _state;
+
+  @override
+  Future<SettingsState?> load() async => _state;
+
+  @override
+  Future<void> save(SettingsState state) async {
+    _state = state;
+  }
+}
+
+class SettingsStorageFactory {
+  const SettingsStorageFactory();
+
+  Future<SettingsStorage> create() async {
+    try {
+      final preferences = await SharedPreferences.getInstance();
+      return SharedPreferencesSettingsStorage(preferences);
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/core/storage/settings_storage.dart',
+        classname: 'SettingsStorageFactory',
+        function: 'create',
+        systemSection: 'settings',
+        message: 'Falling back to in-memory settings storage',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return InMemorySettingsStorage();
+    }
+  }
+}

--- a/mobile/lib/core/utils/uri_utils.dart
+++ b/mobile/lib/core/utils/uri_utils.dart
@@ -1,0 +1,49 @@
+class UriUtils {
+  const UriUtils._();
+
+  static Uri resolveToAbsolute(String rawUrl, Uri base) {
+    final trimmed = rawUrl.trim();
+    if (trimmed.isEmpty) {
+      throw ArgumentError('URL must not be empty');
+    }
+    final uri = Uri.parse(trimmed);
+    if (uri.hasScheme) {
+      return normalize(uri);
+    }
+    return normalize(base.resolveUri(uri));
+  }
+
+  static Uri normalize(Uri uri) {
+    final sanitized = uri.removeFragment();
+    if (sanitized.query.isEmpty) {
+      return sanitized;
+    }
+    final sortedEntries = sanitized.queryParametersAll.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    final buffer = StringBuffer();
+    for (final entry in sortedEntries) {
+      final values = List<String>.from(entry.value)
+        ..sort((a, b) => a.compareTo(b));
+      for (final value in values) {
+        if (buffer.isNotEmpty) {
+          buffer.write('&');
+        }
+        buffer
+          ..write(Uri.encodeQueryComponent(entry.key))
+          ..write('=')
+          ..write(Uri.encodeQueryComponent(value));
+      }
+      if (values.isEmpty) {
+        if (buffer.isNotEmpty) {
+          buffer.write('&');
+        }
+        buffer.write(Uri.encodeQueryComponent(entry.key));
+      }
+    }
+    return sanitized.replace(query: buffer.toString());
+  }
+}
+
+extension on Uri {
+  Uri removeFragment() => replace(fragment: null);
+}

--- a/mobile/lib/features/browser/controllers/browser_controller.dart
+++ b/mobile/lib/features/browser/controllers/browser_controller.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../core/logging/app_logger.dart';
+import '../../../core/result/app_result.dart';
+import '../../../core/utils/uri_utils.dart';
+import '../../extract/controllers/extraction_controller.dart';
+
+class BrowserController extends GetxController {
+  BrowserController(this._extractionController);
+
+  final ExtractionController _extractionController;
+
+  final TextEditingController urlController = TextEditingController();
+  final Rxn<Uri> currentUrl = Rxn<Uri>();
+  final RxnString validationError = RxnString();
+  final RxBool isLoading = false.obs;
+
+  WebViewController? _webViewController;
+
+  void attachWebViewController(WebViewController controller) {
+    _webViewController = controller;
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/controllers/browser_controller.dart',
+      classname: 'BrowserController',
+      function: 'attachWebViewController',
+      systemSection: 'browser',
+      message: 'Attached WebViewController instance',
+    );
+  }
+
+  Future<void> openCurrentUrl() async {
+    final input = urlController.text.trim();
+    if (input.isEmpty) {
+      validationError.value = 'Enter a page URL to open';
+      return;
+    }
+
+    final normalized = _normalizeInput(input);
+    if (normalized == null) {
+      validationError.value = 'Provide a valid http or https URL';
+      return;
+    }
+
+    validationError.value = null;
+    final target = Uri.parse(normalized);
+    currentUrl.value = target;
+    final controller = _webViewController;
+    if (controller == null) {
+      throw StateError('WebViewController has not been attached yet.');
+    }
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/controllers/browser_controller.dart',
+      classname: 'BrowserController',
+      function: 'openCurrentUrl',
+      systemSection: 'browser',
+      message: 'Loading URL $target',
+      method: 'GET',
+    );
+    isLoading.value = true;
+    await controller.loadRequest(target);
+    isLoading.value = false;
+  }
+
+  Future<AppResult<void>> processCurrentPage() async {
+    final controller = _webViewController;
+    final url = currentUrl.value;
+    if (controller == null || url == null) {
+      final error = ValidationError('Open a page before processing');
+      _extractionController.recordError(error);
+      return AppFailure<void>(error);
+    }
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/controllers/browser_controller.dart',
+      classname: 'BrowserController',
+      function: 'processCurrentPage',
+      systemSection: 'browser',
+      message: 'Starting extraction for $url',
+    );
+    return _extractionController.processPage(url, controller);
+  }
+
+  String? _normalizeInput(String input) {
+    final withScheme = input.contains('://') ? input : 'https://$input';
+    try {
+      return UriUtils.normalize(Uri.parse(withScheme)).toString();
+    } on FormatException {
+      return null;
+    }
+  }
+
+  @override
+  void onClose() {
+    urlController.dispose();
+    super.onClose();
+  }
+}

--- a/mobile/lib/features/browser/views/browser_view.dart
+++ b/mobile/lib/features/browser/views/browser_view.dart
@@ -1,0 +1,419 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../core/logging/app_logger.dart';
+import '../../../core/result/app_result.dart';
+import '../../../shared/models/media_item.dart';
+import '../../download/controllers/download_controller.dart';
+import '../../extract/controllers/extraction_controller.dart';
+import '../controllers/browser_controller.dart';
+
+class BrowserView extends StatefulWidget {
+  const BrowserView({super.key});
+
+  @override
+  State<BrowserView> createState() => _BrowserViewState();
+}
+
+class _BrowserViewState extends State<BrowserView> {
+  late final BrowserController _browserController;
+  late final ExtractionController _extractionController;
+  late final DownloadController _downloadController;
+  late final WebViewController _webViewController;
+
+  @override
+  void initState() {
+    super.initState();
+    _browserController = Get.find<BrowserController>();
+    _extractionController = Get.find<ExtractionController>();
+    _downloadController = Get.find<DownloadController>();
+
+    _webViewController = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageStarted: (url) {
+            _browserController.isLoading.value = true;
+            _browserController.currentUrl.value = Uri.tryParse(url);
+          },
+          onPageFinished: (url) {
+            _browserController.isLoading.value = false;
+            _browserController.currentUrl.value = Uri.tryParse(url);
+          },
+          onWebResourceError: (error) {
+            final appError = UnknownError(
+              'Failed to load page',
+              cause: error,
+            );
+            _extractionController.recordError(appError);
+          },
+        ),
+      );
+    _browserController.attachWebViewController(_webViewController);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Butter Knife Browser'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _webViewController.reload(),
+          ),
+        ],
+      ),
+      floatingActionButton: Obx(() {
+        final selectedCount = _extractionController.selectedItems.length;
+        if (selectedCount == 0) {
+          return const SizedBox.shrink();
+        }
+        return FloatingActionButton.extended(
+          onPressed: _downloadSelected,
+          icon: const Icon(Icons.download),
+          label: Text('Download $selectedCount'),
+        );
+      }),
+      body: Column(
+        children: [
+          _UrlInputBar(controller: _browserController),
+          Expanded(
+            child: Row(
+              children: [
+                Expanded(
+                  flex: 2,
+                  child: Stack(
+                    children: [
+                      WebViewWidget(controller: _webViewController),
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        child: Obx(() {
+                          if (_browserController.isLoading.value) {
+                            return const LinearProgressIndicator();
+                          }
+                          return const SizedBox.shrink();
+                        }),
+                      ),
+                      Obx(() {
+                        if (!_extractionController.isProcessing.value) {
+                          return const SizedBox.shrink();
+                        }
+                        return Container(
+                          color: Colors.black.withOpacity(0.6),
+                          child: const Center(
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                CircularProgressIndicator(),
+                                SizedBox(height: 16),
+                                Text(
+                                  'Processing page…',
+                                  style: TextStyle(color: Colors.white),
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      }),
+                    ],
+                  ),
+                ),
+                const VerticalDivider(width: 1),
+                Expanded(
+                  flex: 1,
+                  child: _ExtractionPanel(
+                    extractionController: _extractionController,
+                    downloadController: _downloadController,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _downloadSelected() async {
+    final selected = _extractionController.selectedItems;
+    for (final item in selected) {
+      final result = await _downloadController.download(item);
+      result.when(
+        success: (downloaded) {
+          _extractionController.applyDownloadedItem(downloaded);
+        },
+        failure: (error) {
+          AppLogger.logError(
+            filename: 'lib/features/browser/views/browser_view.dart',
+            classname: '_BrowserViewState',
+            function: '_downloadSelected',
+            systemSection: 'download',
+            message: 'Failed to download ${item.normalizedUrl}',
+            error: error,
+          );
+          Get.snackbar(
+            'Download failed',
+            error.message,
+            backgroundColor: Colors.red.shade700,
+            colorText: Colors.white,
+          );
+        },
+      );
+    }
+  }
+}
+
+class _UrlInputBar extends StatelessWidget {
+  const _UrlInputBar({required this.controller});
+
+  final BrowserController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: controller.urlController,
+                  decoration: const InputDecoration(
+                    hintText: 'Enter a page URL',
+                    border: OutlineInputBorder(),
+                  ),
+                  onSubmitted: (_) => controller.openCurrentUrl(),
+                ),
+              ),
+              const SizedBox(width: 12),
+              FilledButton(
+                onPressed: controller.openCurrentUrl,
+                child: const Text('Open'),
+              ),
+              const SizedBox(width: 12),
+              FilledButton.icon(
+                onPressed: () async {
+                  final result = await controller.processCurrentPage();
+                  result.when(
+                    success: (_) {},
+                    failure: (error) {
+                      Get.snackbar(
+                        'Processing failed',
+                        error.message,
+                        backgroundColor: Colors.red.shade700,
+                        colorText: Colors.white,
+                      );
+                    },
+                  );
+                },
+                icon: const Icon(Icons.auto_awesome),
+                label: const Text('Process'),
+              ),
+            ],
+          ),
+          Obx(() {
+            final error = controller.validationError.value;
+            if (error == null) {
+              return const SizedBox.shrink();
+            }
+            return Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                error,
+                style: const TextStyle(color: Colors.red),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExtractionPanel extends StatelessWidget {
+  const _ExtractionPanel({
+    required this.extractionController,
+    required this.downloadController,
+  });
+
+  final ExtractionController extractionController;
+  final DownloadController downloadController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Obx(() {
+            final count = extractionController.extractedItems.length;
+            final selected = extractionController.selectedItems.length;
+            return Text('Found $count items • Selected $selected');
+          }),
+        ),
+        Obx(() {
+          final error = extractionController.lastError.value;
+          if (error == null) {
+            return const SizedBox.shrink();
+          }
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              error.message,
+              style: const TextStyle(color: Colors.red),
+            ),
+          );
+        }),
+        Expanded(
+          child: Obx(() {
+            final items = extractionController.extractedItems;
+            if (items.isEmpty) {
+              return const Center(
+                child: Text('No media extracted yet.'),
+              );
+            }
+            return ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final item = items[index];
+                return _MediaListTile(
+                  item: item,
+                  onToggleSelected: () => extractionController.toggleSelection(item.id),
+                  onDownload: () async {
+                    final result = await downloadController.download(item);
+                    result.when(
+                      success: (downloaded) {
+                        extractionController.applyDownloadedItem(downloaded);
+                      },
+                      failure: (error) {
+                        _showDownloadError(context, error);
+                      },
+                    );
+                  },
+                );
+              },
+            );
+          }),
+        ),
+      ],
+    );
+  }
+
+  void _showDownloadError(BuildContext context, AppError error) {
+    AppLogger.logError(
+      filename: 'lib/features/browser/views/browser_view.dart',
+      classname: '_ExtractionPanel',
+      function: '_showDownloadError',
+      systemSection: 'download',
+      message: error.message,
+      error: error,
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Download failed: ${error.message}'),
+        backgroundColor: Colors.red,
+      ),
+    );
+  }
+}
+
+class _MediaListTile extends StatelessWidget {
+  const _MediaListTile({
+    required this.item,
+    required this.onToggleSelected,
+    required this.onDownload,
+  });
+
+  final MediaItem item;
+  final VoidCallback onToggleSelected;
+  final VoidCallback onDownload;
+
+  @override
+  Widget build(BuildContext context) {
+    final downloadController = Get.find<DownloadController>();
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        leading: _MediaThumbnail(item: item),
+        title: Text(
+          item.normalizedUrl.toString(),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text('${item.type.name.toUpperCase()} • ${item.contentLength ?? 0} bytes'),
+        trailing: Obx(() {
+          final progress = downloadController.taskProgress[item.id];
+          if (progress == null) {
+            return IconButton(
+              icon: const Icon(Icons.download),
+              onPressed: onDownload,
+            );
+          }
+          switch (progress.phase) {
+            case DownloadPhase.queued:
+              return const SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              );
+            case DownloadPhase.inProgress:
+              return SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(
+                  value: progress.progress == 0 ? null : progress.progress,
+                  strokeWidth: 2,
+                ),
+              );
+            case DownloadPhase.completed:
+              return const Icon(Icons.check_circle, color: Colors.green);
+            case DownloadPhase.failed:
+              return IconButton(
+                icon: const Icon(Icons.error, color: Colors.red),
+                onPressed: onDownload,
+              );
+          }
+        }),
+        selected: item.isSelected,
+        onTap: onToggleSelected,
+      ),
+    );
+  }
+}
+
+class _MediaThumbnail extends StatelessWidget {
+  const _MediaThumbnail({required this.item});
+
+  final MediaItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final thumbnailUrl = item.thumbnailUrl ?? item.normalizedUrl;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Image.network(
+        thumbnailUrl.toString(),
+        width: 48,
+        height: 48,
+        fit: BoxFit.cover,
+        errorBuilder: (context, error, stackTrace) {
+          return Container(
+            width: 48,
+            height: 48,
+            color: Colors.grey.shade300,
+            alignment: Alignment.center,
+            child: const Icon(Icons.broken_image),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/download/controllers/download_controller.dart
+++ b/mobile/lib/features/download/controllers/download_controller.dart
@@ -1,0 +1,145 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:get/get.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../core/logging/app_logger.dart';
+import '../../../core/result/app_result.dart';
+import '../../../shared/models/media_item.dart';
+
+enum DownloadPhase { queued, inProgress, completed, failed }
+
+class DownloadProgress {
+  const DownloadProgress({
+    required this.phase,
+    required this.progress,
+    this.error,
+  });
+
+  const DownloadProgress.queued()
+      : phase = DownloadPhase.queued,
+        progress = 0,
+        error = null;
+
+  const DownloadProgress.inProgress(double progressValue)
+      : phase = DownloadPhase.inProgress,
+        progress = progressValue,
+        error = null;
+
+  const DownloadProgress.completed()
+      : phase = DownloadPhase.completed,
+        progress = 1,
+        error = null;
+
+  const DownloadProgress.failed(AppError errorValue)
+      : phase = DownloadPhase.failed,
+        progress = 0,
+        error = errorValue;
+
+  final DownloadPhase phase;
+  final double progress;
+  final AppError? error;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'phase': phase.name,
+        'progress': progress,
+        'error': error?.toJson(),
+      };
+}
+
+class DownloadController extends GetxController {
+  DownloadController(this._dio);
+
+  final Dio _dio;
+
+  final RxMap<String, DownloadProgress> taskProgress = <String, DownloadProgress>{}.obs;
+  final RxList<MediaItem> completedDownloads = <MediaItem>[].obs;
+
+  Future<AppResult<MediaItem>> download(MediaItem item) async {
+    taskProgress[item.id] = const DownloadProgress.queued();
+    AppLogger.logInfo(
+      filename: 'lib/features/download/controllers/download_controller.dart',
+      classname: 'DownloadController',
+      function: 'download',
+      systemSection: 'download',
+      message: 'Starting download for ${item.normalizedUrl}',
+      method: 'GET',
+    );
+    try {
+      final response = await _dio.getUri<List<int>>(
+        item.normalizedUrl,
+        options: Options(
+          responseType: ResponseType.bytes,
+          followRedirects: true,
+          validateStatus: (status) => status != null && status < 400,
+        ),
+        onReceiveProgress: (received, total) {
+          if (total <= 0) {
+            taskProgress[item.id] = const DownloadProgress.inProgress(0);
+            return;
+          }
+          taskProgress[item.id] = DownloadProgress.inProgress(received / total);
+        },
+      );
+      final bytes = Uint8List.fromList(response.data ?? <int>[]);
+      final updatedItem = item.copyWith(
+        bytes: bytes,
+        contentLength: bytes.length,
+      );
+      completedDownloads.add(updatedItem);
+      taskProgress[item.id] = const DownloadProgress.completed();
+      AppLogger.logInfo(
+        filename: 'lib/features/download/controllers/download_controller.dart',
+        classname: 'DownloadController',
+        function: 'download',
+        systemSection: 'download',
+        message: 'Completed download for ${item.normalizedUrl}',
+      );
+      return AppSuccess<MediaItem>(updatedItem);
+    } on DioException catch (error, stackTrace) {
+      final networkError = NetworkError(
+        'Failed to download ${item.normalizedUrl}',
+        statusCode: error.response?.statusCode,
+        stackTrace: stackTrace,
+      );
+      taskProgress[item.id] = DownloadProgress.failed(networkError);
+      AppLogger.logError(
+        filename: 'lib/features/download/controllers/download_controller.dart',
+        classname: 'DownloadController',
+        function: 'download',
+        systemSection: 'download',
+        message: networkError.message,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return AppFailure<MediaItem>(networkError);
+    } catch (error, stackTrace) {
+      final appError = UnknownError(
+        'Unexpected error during download',
+        cause: error,
+        stackTrace: stackTrace,
+      );
+      taskProgress[item.id] = DownloadProgress.failed(appError);
+      AppLogger.logError(
+        filename: 'lib/features/download/controllers/download_controller.dart',
+        classname: 'DownloadController',
+        function: 'download',
+        systemSection: 'download',
+        message: appError.message,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return AppFailure<MediaItem>(appError);
+    }
+  }
+
+  Future<List<AppResult<MediaItem>>> downloadAll(Iterable<MediaItem> items) async {
+    final results = <AppResult<MediaItem>>[];
+    for (final item in items) {
+      final result = await download(item);
+      results.add(result);
+    }
+    return results;
+  }
+}

--- a/mobile/lib/features/extract/controllers/extraction_controller.dart
+++ b/mobile/lib/features/extract/controllers/extraction_controller.dart
@@ -1,0 +1,289 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:get/get.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../core/logging/app_logger.dart';
+import '../../../core/result/app_result.dart';
+import '../../../core/utils/uri_utils.dart';
+import '../../../shared/models/extraction_result.dart';
+import '../../../shared/models/media_item.dart';
+
+class ExtractionController extends GetxController {
+  ExtractionController(this._dio);
+
+  final Dio _dio;
+
+  final RxBool isProcessing = false.obs;
+  final RxList<MediaItem> extractedItems = <MediaItem>[].obs;
+  final Rx<SkippedStats> skippedStats = const SkippedStats().obs;
+  final Rxn<AppError> lastError = Rxn<AppError>();
+
+  Future<AppResult<void>> processPage(
+    Uri pageUrl,
+    WebViewController webViewController,
+  ) async {
+    isProcessing.value = true;
+    lastError.value = null;
+    skippedStats.value = const SkippedStats();
+
+    AppLogger.logInfo(
+      filename: 'lib/features/extract/controllers/extraction_controller.dart',
+      classname: 'ExtractionController',
+      function: 'processPage',
+      systemSection: 'extraction',
+      message: 'Injecting DOM scanner for $pageUrl',
+    );
+
+    try {
+      final rawResult = await webViewController.runJavaScriptReturningResult(_domScannerScript);
+      final jsonPayload = _coerceResult(rawResult);
+      final decoded = jsonDecode(jsonPayload) as Map<String, dynamic>;
+      final candidates = decoded['images'] as List<dynamic>? ?? <dynamic>[];
+      final mediaItems = <MediaItem>[];
+      for (var index = 0; index < candidates.length; index++) {
+        final candidate = candidates[index] as Map<String, dynamic>;
+        final rawSrc = candidate['src'] as String?;
+        if (rawSrc == null || rawSrc.isEmpty) {
+          continue;
+        }
+        try {
+          final resolved = UriUtils.resolveToAbsolute(rawSrc, pageUrl);
+          mediaItems.add(
+            MediaItem(
+              id: candidate['id'] as String? ?? 'media-$index',
+              type: _mediaTypeFromTag(candidate['tag'] as String? ?? 'img'),
+              url: resolved,
+              normalizedUrl: UriUtils.normalize(resolved),
+              width: (candidate['width'] as num?)?.toInt(),
+              height: (candidate['height'] as num?)?.toInt(),
+              thumbnailUrl: _parseOptionalUri(candidate['poster'] as String?, pageUrl),
+            ),
+          );
+        } on ArgumentError catch (error, stackTrace) {
+          AppLogger.logError(
+            filename: 'lib/features/extract/controllers/extraction_controller.dart',
+            classname: 'ExtractionController',
+            function: 'processPage',
+            systemSection: 'extraction',
+            message: 'Failed to resolve candidate URL: $rawSrc',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+      }
+      final probedItems = <MediaItem>[];
+      for (final item in mediaItems) {
+        final probed = await _probeCandidate(item);
+        probedItems.add(probed);
+      }
+      extractedItems.assignAll(probedItems);
+      AppLogger.logInfo(
+        filename: 'lib/features/extract/controllers/extraction_controller.dart',
+        classname: 'ExtractionController',
+        function: 'processPage',
+        systemSection: 'extraction',
+        message: 'Extracted ${probedItems.length} media candidates',
+      );
+      return AppSuccess<void>(null);
+    } on Exception catch (error, stackTrace) {
+      final appError = UnknownError('Failed to analyze page', cause: error, stackTrace: stackTrace);
+      recordError(appError);
+      return AppFailure<void>(appError);
+    } finally {
+      isProcessing.value = false;
+    }
+  }
+
+  void recordError(AppError error) {
+    lastError.value = error;
+    AppLogger.logError(
+      filename: 'lib/features/extract/controllers/extraction_controller.dart',
+      classname: 'ExtractionController',
+      function: 'recordError',
+      systemSection: 'extraction',
+      message: error.message,
+      error: error,
+      stackTrace: error.stackTrace,
+    );
+  }
+
+  Future<MediaItem> _probeCandidate(MediaItem item) async {
+    AppLogger.logDebug(
+      filename: 'lib/features/extract/controllers/extraction_controller.dart',
+      classname: 'ExtractionController',
+      function: '_probeCandidate',
+      systemSection: 'extraction',
+      message: 'Probing ${item.normalizedUrl}',
+      method: 'HEAD',
+    );
+    try {
+      final response = await _dio.headUri(
+        item.normalizedUrl,
+        options: Options(
+          followRedirects: true,
+          validateStatus: (status) => status != null && status < 400,
+        ),
+      );
+      final contentType = response.headers.value('content-type');
+      final contentLengthHeader = response.headers.value('content-length');
+      final contentLength = contentLengthHeader == null
+          ? null
+          : int.tryParse(contentLengthHeader);
+      final type = _classifyByContentType(contentType, item.type);
+      return item.copyWith(
+        contentLength: contentLength,
+        type: type,
+      );
+    } on DioException catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/extract/controllers/extraction_controller.dart',
+        classname: 'ExtractionController',
+        function: '_probeCandidate',
+        systemSection: 'extraction',
+        message: 'HEAD request failed for ${item.normalizedUrl}',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return item;
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/extract/controllers/extraction_controller.dart',
+        classname: 'ExtractionController',
+        function: '_probeCandidate',
+        systemSection: 'extraction',
+        message: 'Unexpected error while probing ${item.normalizedUrl}',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return item;
+    }
+  }
+
+  static String _coerceResult(Object? rawResult) {
+    if (rawResult == null) {
+      return '{}';
+    }
+    if (rawResult is String) {
+      if (rawResult.startsWith('"') && rawResult.endsWith('"')) {
+        return jsonDecode(rawResult) as String;
+      }
+      return rawResult;
+    }
+    return jsonEncode(rawResult);
+  }
+
+  static MediaType _mediaTypeFromTag(String tag) {
+    switch (tag.toLowerCase()) {
+      case 'video':
+        return MediaType.video;
+      default:
+        return MediaType.image;
+    }
+  }
+
+  static MediaType _classifyByContentType(String? contentType, MediaType fallback) {
+    final normalized = contentType?.toLowerCase() ?? '';
+    if (normalized.startsWith('image/')) {
+      return MediaType.image;
+    }
+    if (normalized.startsWith('video/')) {
+      return MediaType.video;
+    }
+    if (normalized.contains('mpegurl') || normalized.contains('mp2t')) {
+      return MediaType.streaming;
+    }
+    return fallback;
+  }
+
+  void toggleSelection(String id) {
+    final index = extractedItems.indexWhere((item) => item.id == id);
+    if (index == -1) {
+      return;
+    }
+    final current = extractedItems[index];
+    extractedItems[index] = current.copyWith(isSelected: !current.isSelected);
+    extractedItems.refresh();
+  }
+
+  void applyDownloadedItem(MediaItem item) {
+    final index = extractedItems.indexWhere((element) => element.id == item.id);
+    if (index == -1) {
+      return;
+    }
+    extractedItems[index] = item;
+    extractedItems.refresh();
+  }
+
+  List<MediaItem> get selectedItems =>
+      extractedItems.where((item) => item.isSelected).toList(growable: false);
+
+  static Uri? _parseOptionalUri(String? value, Uri base) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    try {
+      return UriUtils.resolveToAbsolute(value, base);
+    } on ArgumentError {
+      return null;
+    }
+  }
+}
+
+const String _domScannerScript = r'''
+(() => {
+  const pickSrc = (element) => {
+    if (!element) {
+      return '';
+    }
+    if (element.currentSrc) {
+      return element.currentSrc;
+    }
+    if (element.srcset) {
+      const parts = element.srcset.split(',').map((item) => item.trim());
+      if (parts.length > 0) {
+        return parts[parts.length - 1].split(' ')[0];
+      }
+    }
+    return element.src || '';
+  };
+
+  const images = Array.from(document.querySelectorAll('img, picture source, video')).map((element, index) => {
+    let tag = element.tagName.toLowerCase();
+    let src = '';
+    let poster = '';
+    let width = element.naturalWidth || element.videoWidth || element.clientWidth || 0;
+    let height = element.naturalHeight || element.videoHeight || element.clientHeight || 0;
+
+    if (tag === 'source') {
+      const parent = element.parentElement;
+      if (parent && parent.tagName.toLowerCase() === 'picture') {
+        tag = 'img';
+        src = pickSrc(element);
+        width = parent.clientWidth;
+        height = parent.clientHeight;
+      }
+    } else if (tag === 'video') {
+      src = pickSrc(element.querySelector('source')) || element.currentSrc || element.src || '';
+      poster = element.poster || '';
+      width = element.videoWidth || element.clientWidth || 0;
+      height = element.videoHeight || element.clientHeight || 0;
+    } else {
+      src = pickSrc(element);
+    }
+
+    return {
+      id: `${tag}-${index}`,
+      tag,
+      src,
+      poster,
+      width,
+      height,
+    };
+  });
+
+  return JSON.stringify({ images });
+})();
+''';

--- a/mobile/lib/features/settings/controllers/settings_controller.dart
+++ b/mobile/lib/features/settings/controllers/settings_controller.dart
@@ -1,0 +1,84 @@
+import 'package:get/get.dart';
+
+import '../../../core/logging/app_logger.dart';
+import '../../../core/storage/settings_storage.dart';
+import '../models/settings_state.dart';
+
+class SettingsController extends GetxController {
+  SettingsController(this._storage);
+
+  final SettingsStorage _storage;
+
+  final Rx<SettingsState> state = SettingsState.initial().obs;
+  final RxBool isReady = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _load();
+  }
+
+  Future<void> _load() async {
+    AppLogger.logInfo(
+      filename: 'lib/features/settings/controllers/settings_controller.dart',
+      classname: 'SettingsController',
+      function: '_load',
+      systemSection: 'settings',
+      message: 'Loading persisted settings',
+    );
+    try {
+      final stored = await _storage.load();
+      if (stored != null) {
+        state.value = stored;
+      }
+      isReady.value = true;
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/settings/controllers/settings_controller.dart',
+        classname: 'SettingsController',
+        function: '_load',
+        systemSection: 'settings',
+        message: 'Failed to load settings',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      isReady.value = true;
+    }
+  }
+
+  Future<void> updateSettings(SettingsState newState) async {
+    state.value = newState;
+    await _storage.save(newState);
+    AppLogger.logInfo(
+      filename: 'lib/features/settings/controllers/settings_controller.dart',
+      classname: 'SettingsController',
+      function: 'updateSettings',
+      systemSection: 'settings',
+      message: 'Persisted settings update',
+    );
+  }
+
+  Future<void> setMinImageBytes(int value) => updateSettings(
+        state.value.copyWith(minImageBytes: value),
+      );
+
+  Future<void> toggleDesktopUserAgent(bool enabled) => updateSettings(
+        state.value.copyWith(useDesktopUserAgent: enabled),
+      );
+
+  Future<void> setConcurrentDownloads(int value) => updateSettings(
+        state.value.copyWith(concurrentDownloads: value),
+      );
+
+  Future<void> toggleSvg(bool enabled) => updateSettings(
+        state.value.copyWith(includeSvg: enabled),
+      );
+
+  Future<void> toggleGif(bool enabled) => updateSettings(
+        state.value.copyWith(includeGif: enabled),
+      );
+
+  Future<void> toggleAutoplayThumbnails(bool enabled) => updateSettings(
+        state.value.copyWith(includeAutoplayThumbnails: enabled),
+      );
+}

--- a/mobile/lib/features/settings/models/settings_state.dart
+++ b/mobile/lib/features/settings/models/settings_state.dart
@@ -1,0 +1,86 @@
+class SettingsState {
+  const SettingsState({
+    required this.minImageBytes,
+    required this.useDesktopUserAgent,
+    required this.concurrentDownloads,
+    required this.includeSvg,
+    required this.includeGif,
+    required this.includeAutoplayThumbnails,
+  });
+
+  factory SettingsState.initial() => const SettingsState(
+        minImageBytes: 10240,
+        useDesktopUserAgent: false,
+        concurrentDownloads: 3,
+        includeSvg: true,
+        includeGif: true,
+        includeAutoplayThumbnails: false,
+      );
+
+  factory SettingsState.fromJson(Map<String, dynamic> json) => SettingsState(
+        minImageBytes: json['minImageBytes'] as int? ?? 10240,
+        useDesktopUserAgent: json['useDesktopUserAgent'] as bool? ?? false,
+        concurrentDownloads: json['concurrentDownloads'] as int? ?? 3,
+        includeSvg: json['includeSvg'] as bool? ?? true,
+        includeGif: json['includeGif'] as bool? ?? true,
+        includeAutoplayThumbnails: json['includeAutoplayThumbnails'] as bool? ?? false,
+      );
+
+  final int minImageBytes;
+  final bool useDesktopUserAgent;
+  final int concurrentDownloads;
+  final bool includeSvg;
+  final bool includeGif;
+  final bool includeAutoplayThumbnails;
+
+  SettingsState copyWith({
+    int? minImageBytes,
+    bool? useDesktopUserAgent,
+    int? concurrentDownloads,
+    bool? includeSvg,
+    bool? includeGif,
+    bool? includeAutoplayThumbnails,
+  }) =>
+      SettingsState(
+        minImageBytes: minImageBytes ?? this.minImageBytes,
+        useDesktopUserAgent: useDesktopUserAgent ?? this.useDesktopUserAgent,
+        concurrentDownloads: concurrentDownloads ?? this.concurrentDownloads,
+        includeSvg: includeSvg ?? this.includeSvg,
+        includeGif: includeGif ?? this.includeGif,
+        includeAutoplayThumbnails:
+            includeAutoplayThumbnails ?? this.includeAutoplayThumbnails,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'minImageBytes': minImageBytes,
+        'useDesktopUserAgent': useDesktopUserAgent,
+        'concurrentDownloads': concurrentDownloads,
+        'includeSvg': includeSvg,
+        'includeGif': includeGif,
+        'includeAutoplayThumbnails': includeAutoplayThumbnails,
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is SettingsState &&
+        other.minImageBytes == minImageBytes &&
+        other.useDesktopUserAgent == useDesktopUserAgent &&
+        other.concurrentDownloads == concurrentDownloads &&
+        other.includeSvg == includeSvg &&
+        other.includeGif == includeGif &&
+        other.includeAutoplayThumbnails == includeAutoplayThumbnails;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        minImageBytes,
+        useDesktopUserAgent,
+        concurrentDownloads,
+        includeSvg,
+        includeGif,
+        includeAutoplayThumbnails,
+      );
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+import 'app.dart';
+import 'core/logging/app_logger.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  AppLogger.logInfo(
+    filename: 'lib/main.dart',
+    classname: 'main',
+    function: 'main',
+    systemSection: 'bootstrap',
+    message: 'Starting Butter Knife Flutter application',
+  );
+  runApp(const ButterKnifeApp());
+}

--- a/mobile/lib/shared/models/extraction_result.dart
+++ b/mobile/lib/shared/models/extraction_result.dart
@@ -1,0 +1,113 @@
+import 'media_item.dart';
+
+class SkippedStats {
+  const SkippedStats({
+    this.faviconCount = 0,
+    this.smallAssetCount = 0,
+    this.streamingCount = 0,
+  });
+
+  factory SkippedStats.fromJson(Map<String, dynamic> json) => SkippedStats(
+        faviconCount: json['faviconCount'] as int? ?? 0,
+        smallAssetCount: json['smallAssetCount'] as int? ?? 0,
+        streamingCount: json['streamingCount'] as int? ?? 0,
+      );
+
+  final int faviconCount;
+  final int smallAssetCount;
+  final int streamingCount;
+
+  SkippedStats copyWith({
+    int? faviconCount,
+    int? smallAssetCount,
+    int? streamingCount,
+  }) =>
+      SkippedStats(
+        faviconCount: faviconCount ?? this.faviconCount,
+        smallAssetCount: smallAssetCount ?? this.smallAssetCount,
+        streamingCount: streamingCount ?? this.streamingCount,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'faviconCount': faviconCount,
+        'smallAssetCount': smallAssetCount,
+        'streamingCount': streamingCount,
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is SkippedStats &&
+        other.faviconCount == faviconCount &&
+        other.smallAssetCount == smallAssetCount &&
+        other.streamingCount == streamingCount;
+  }
+
+  @override
+  int get hashCode => Object.hash(faviconCount, smallAssetCount, streamingCount);
+}
+
+class ExtractionResult {
+  const ExtractionResult({
+    required this.pageUrl,
+    required this.found,
+    required this.skipped,
+  });
+
+  factory ExtractionResult.fromJson(Map<String, dynamic> json) => ExtractionResult(
+        pageUrl: Uri.parse(json['pageUrl'] as String),
+        found: (json['found'] as List<dynamic>)
+            .map((dynamic item) => MediaItem.fromJson(item as Map<String, dynamic>))
+            .toList(),
+        skipped: SkippedStats.fromJson(json['skipped'] as Map<String, dynamic>),
+      );
+
+  final Uri pageUrl;
+  final List<MediaItem> found;
+  final SkippedStats skipped;
+
+  ExtractionResult copyWith({
+    Uri? pageUrl,
+    List<MediaItem>? found,
+    SkippedStats? skipped,
+  }) =>
+      ExtractionResult(
+        pageUrl: pageUrl ?? this.pageUrl,
+        found: found ?? this.found,
+        skipped: skipped ?? this.skipped,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'pageUrl': pageUrl.toString(),
+        'found': found.map((item) => item.toJson()).toList(),
+        'skipped': skipped.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is ExtractionResult &&
+        other.pageUrl == pageUrl &&
+        _listEquals(other.found, found) &&
+        other.skipped == skipped;
+  }
+
+  @override
+  int get hashCode => Object.hash(pageUrl, Object.hashAll(found), skipped);
+}
+
+bool _listEquals<T>(List<T> a, List<T> b) {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/mobile/lib/shared/models/media_item.dart
+++ b/mobile/lib/shared/models/media_item.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+
+enum MediaType { image, video, streaming }
+
+class MediaItem {
+  const MediaItem({
+    required this.id,
+    required this.type,
+    required this.url,
+    required this.normalizedUrl,
+    this.width,
+    this.height,
+    this.bytes,
+    this.contentLength,
+    this.thumbnailUrl,
+    this.isSelected = false,
+  });
+
+  factory MediaItem.fromJson(Map<String, dynamic> json) {
+    final rawBytes = json['bytes'] as String?;
+    return MediaItem(
+      id: json['id'] as String,
+      type: _mediaTypeFromJson(json['type'] as String),
+      url: Uri.parse(json['url'] as String),
+      normalizedUrl: Uri.parse(json['normalizedUrl'] as String),
+      width: json['width'] as int?,
+      height: json['height'] as int?,
+      bytes: rawBytes == null ? null : base64Decode(rawBytes),
+      contentLength: json['contentLength'] as int?,
+      thumbnailUrl: (json['thumbnailUrl'] as String?)?.let(Uri.parse),
+      isSelected: json['isSelected'] as bool? ?? false,
+    );
+  }
+
+  final String id;
+  final MediaType type;
+  final Uri url;
+  final Uri normalizedUrl;
+  final int? width;
+  final int? height;
+  final Uint8List? bytes;
+  final int? contentLength;
+  final Uri? thumbnailUrl;
+  final bool isSelected;
+
+  MediaItem copyWith({
+    String? id,
+    MediaType? type,
+    Uri? url,
+    Uri? normalizedUrl,
+    int? width,
+    int? height,
+    Uint8List? bytes,
+    int? contentLength,
+    Uri? thumbnailUrl,
+    bool? isSelected,
+  }) {
+    return MediaItem(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      url: url ?? this.url,
+      normalizedUrl: normalizedUrl ?? this.normalizedUrl,
+      width: width ?? this.width,
+      height: height ?? this.height,
+      bytes: bytes ?? this.bytes,
+      contentLength: contentLength ?? this.contentLength,
+      thumbnailUrl: thumbnailUrl ?? this.thumbnailUrl,
+      isSelected: isSelected ?? this.isSelected,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'type': type.name,
+        'url': url.toString(),
+        'normalizedUrl': normalizedUrl.toString(),
+        'width': width,
+        'height': height,
+        'bytes': bytes == null ? null : base64Encode(bytes!),
+        'contentLength': contentLength,
+        'thumbnailUrl': thumbnailUrl?.toString(),
+        'isSelected': isSelected,
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is MediaItem &&
+        other.id == id &&
+        other.type == type &&
+        other.url == url &&
+        other.normalizedUrl == normalizedUrl &&
+        other.width == width &&
+        other.height == height &&
+        listEquals(other.bytes, bytes) &&
+        other.contentLength == contentLength &&
+        other.thumbnailUrl == thumbnailUrl &&
+        other.isSelected == isSelected;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        type,
+        url,
+        normalizedUrl,
+        width,
+        height,
+        bytes == null ? null : base64Encode(bytes!),
+        contentLength,
+        thumbnailUrl,
+        isSelected,
+      );
+}
+
+MediaType _mediaTypeFromJson(String raw) {
+  return MediaType.values.firstWhere(
+    (type) => type.name == raw,
+    orElse: () => MediaType.image,
+  );
+}
+
+extension<T> on T {
+  R let<R>(R Function(T value) transform) => transform(this);
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,0 +1,27 @@
+name: butterknife_app
+description: Butter Knife mobile Flutter application scaffold with feature-first architecture.
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.22.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  get: ^4.6.6
+  dio: ^5.4.2+1
+  webview_flutter: ^4.7.0
+  html: ^0.15.4
+  shared_preferences: ^2.2.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.2
+  mocktail: ^1.0.3
+
+flutter:
+  uses-material-design: true

--- a/mobile/test/extraction_result_test.dart
+++ b/mobile/test/extraction_result_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:butterknife_app/shared/models/extraction_result.dart';
+import 'package:butterknife_app/shared/models/media_item.dart';
+
+void main() {
+  group('ExtractionResult', () {
+    test('serializes and deserializes correctly', () {
+      final item = MediaItem(
+        id: 'a',
+        type: MediaType.image,
+        url: Uri.parse('https://example.com/a.jpg'),
+        normalizedUrl: Uri.parse('https://example.com/a.jpg'),
+      );
+      final result = ExtractionResult(
+        pageUrl: Uri.parse('https://example.com'),
+        found: [item],
+        skipped: const SkippedStats(faviconCount: 1, smallAssetCount: 2),
+      );
+
+      final json = result.toJson();
+      final roundTrip = ExtractionResult.fromJson(json);
+
+      expect(roundTrip.pageUrl, result.pageUrl);
+      expect(roundTrip.found, result.found);
+      expect(roundTrip.skipped, result.skipped);
+    });
+  });
+}

--- a/mobile/test/media_item_test.dart
+++ b/mobile/test/media_item_test.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:butterknife_app/shared/models/media_item.dart';
+
+void main() {
+  group('MediaItem', () {
+    test('serializes and deserializes with bytes', () {
+      final item = MediaItem(
+        id: 'id-1',
+        type: MediaType.image,
+        url: Uri.parse('https://example.com/image.png'),
+        normalizedUrl: Uri.parse('https://example.com/image.png'),
+        width: 200,
+        height: 100,
+        bytes: Uint8List.fromList(utf8.encode('pixels')),
+        contentLength: 6,
+        thumbnailUrl: Uri.parse('https://example.com/thumb.png'),
+        isSelected: true,
+      );
+
+      final roundTrip = MediaItem.fromJson(item.toJson());
+      expect(roundTrip, equals(item));
+      expect(roundTrip.bytes, isNotNull);
+      expect(roundTrip.bytes, equals(item.bytes));
+    });
+
+    test('copyWith updates fields immutably', () {
+      final item = MediaItem(
+        id: 'id-1',
+        type: MediaType.image,
+        url: Uri.parse('https://example.com/a.jpg'),
+        normalizedUrl: Uri.parse('https://example.com/a.jpg'),
+      );
+
+      final updated = item.copyWith(isSelected: true, width: 640);
+      expect(updated.isSelected, isTrue);
+      expect(updated.width, 640);
+      expect(item.isSelected, isFalse);
+      expect(item.width, isNull);
+    });
+  });
+}

--- a/mobile/test/settings_state_test.dart
+++ b/mobile/test/settings_state_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:butterknife_app/features/settings/models/settings_state.dart';
+
+void main() {
+  group('SettingsState', () {
+    test('copyWith returns new instance', () {
+      const state = SettingsState.initial();
+      final updated = state.copyWith(minImageBytes: 20480, includeGif: false);
+      expect(updated.minImageBytes, 20480);
+      expect(updated.includeGif, isFalse);
+      expect(state.minImageBytes, isNot(20480));
+      expect(state.includeGif, isTrue);
+    });
+
+    test('serializes to and from json', () {
+      const state = SettingsState.initial();
+      final json = state.toJson();
+      final parsed = SettingsState.fromJson(json);
+      expect(parsed, equals(state));
+    });
+  });
+}

--- a/mobile/test/uri_utils_test.dart
+++ b/mobile/test/uri_utils_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:butterknife_app/core/utils/uri_utils.dart';
+
+void main() {
+  group('UriUtils', () {
+    test('resolves relative URLs', () {
+      final base = Uri.parse('https://example.com/path/page');
+      final resolved = UriUtils.resolveToAbsolute('../image.png', base);
+      expect(resolved.toString(), 'https://example.com/image.png');
+    });
+
+    test('normalizes query parameters order', () {
+      final uri = Uri.parse('https://example.com?a=1&b=2&a=3#hash');
+      final normalized = UriUtils.normalize(uri);
+      expect(normalized.toString(), 'https://example.com?a=1&a=3&b=2');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Flutter project under `mobile/` with GetX bindings, structured logging, and feature-first layout
- implement media models, DOM extraction pipeline, download handling, and settings persistence scaffolding
- build browser view with WebView-powered processing, selection UI, and download triggers plus supporting unit tests

## Testing
- `flutter test` *(fails: flutter command not available in execution environment)*
- `flutter analyze` *(fails: flutter command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b306c788832b95721ed5974da7c7