### PR TITLE
Add media preview and download path controls

### DIFF
--- a/mobile/lib/features/browser/controllers/browser_controller.dart
+++ b/mobile/lib/features/browser/controllers/browser_controller.dart
@@ -17,6 +17,7 @@ class BrowserController extends GetxController {
   final Rxn<Uri> currentUrl = Rxn<Uri>();
   final RxnString validationError = RxnString();
   final RxBool isLoading = false.obs;
+  final RxBool showControls = true.obs;
 
   WebViewController? _webViewController;
 
@@ -80,6 +81,20 @@ class BrowserController extends GetxController {
       message: 'Starting extraction for $url',
     );
     return _extractionController.processPage(url, controller);
+  }
+
+  void toggleControlsVisibility() {
+    final newVisibility = !showControls.value;
+    showControls.value = newVisibility;
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/controllers/browser_controller.dart',
+      classname: 'BrowserController',
+      function: 'toggleControlsVisibility',
+      systemSection: 'browser',
+      message: newVisibility
+          ? 'Showing browser controls'
+          : 'Hiding browser controls',
+    );
   }
 
   String? _normalizeInput(String input) {

--- a/mobile/lib/features/browser/views/browser_view.dart
+++ b/mobile/lib/features/browser/views/browser_view.dart
@@ -1,5 +1,7 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:video_player/video_player.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import '../../../core/errors/app_error.dart';
@@ -8,6 +10,7 @@ import '../../../core/result/app_result.dart';
 import '../../../shared/models/media_item.dart';
 import '../../download/controllers/download_controller.dart';
 import '../../extract/controllers/extraction_controller.dart';
+import '../../settings/controllers/settings_controller.dart';
 import '../controllers/browser_controller.dart';
 
 class BrowserView extends StatefulWidget {
@@ -21,6 +24,7 @@ class _BrowserViewState extends State<BrowserView> {
   late final BrowserController _browserController;
   late final ExtractionController _extractionController;
   late final DownloadController _downloadController;
+  late final SettingsController _settingsController;
   late final WebViewController _webViewController;
 
   @override
@@ -29,6 +33,7 @@ class _BrowserViewState extends State<BrowserView> {
     _browserController = Get.find<BrowserController>();
     _extractionController = Get.find<ExtractionController>();
     _downloadController = Get.find<DownloadController>();
+    _settingsController = Get.find<SettingsController>();
 
     _webViewController = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
@@ -60,6 +65,22 @@ class _BrowserViewState extends State<BrowserView> {
       appBar: AppBar(
         title: const Text('Butter Knife Browser'),
         actions: [
+          Obx(() {
+            final isVisible = _browserController.showControls.value;
+            return IconButton(
+              icon: Icon(isVisible ? Icons.menu_open : Icons.menu),
+              tooltip: isVisible ? 'Hide address bar' : 'Show address bar',
+              onPressed: _browserController.toggleControlsVisibility,
+            );
+          }),
+          Obx(() {
+            final ready = _settingsController.isReady.value;
+            return IconButton(
+              icon: const Icon(Icons.settings),
+              tooltip: 'Download destinations',
+              onPressed: ready ? _openDownloadSettings : null,
+            );
+          }),
           IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: () => _webViewController.reload(),
@@ -79,7 +100,12 @@ class _BrowserViewState extends State<BrowserView> {
       }),
       body: Column(
         children: [
-          _UrlInputBar(controller: _browserController),
+          Obx(() {
+            if (_browserController.showControls.value) {
+              return _UrlInputBar(controller: _browserController);
+            }
+            return const SizedBox.shrink();
+          }),
           Expanded(
             child: Row(
               children: [
@@ -137,6 +163,106 @@ class _BrowserViewState extends State<BrowserView> {
         ],
       ),
     );
+  }
+
+  Future<void> _openDownloadSettings() async {
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/views/browser_view.dart',
+      classname: '_BrowserViewState',
+      function: '_openDownloadSettings',
+      systemSection: 'settings',
+      message: 'Opening download destinations sheet',
+    );
+    if (!mounted) {
+      return;
+    }
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => _DownloadSettingsSheet(
+        settingsController: _settingsController,
+        onPickImageDirectory: () => _pickDirectory(
+          mediaType: 'image',
+          onSelected: (path) => _settingsController.setImageSaveDirectory(path),
+        ),
+        onPickVideoDirectory: () => _pickDirectory(
+          mediaType: 'video',
+          onSelected: (path) => _settingsController.setVideoSaveDirectory(path),
+        ),
+        onClearImageDirectory: () => _clearDirectory(isVideo: false),
+        onClearVideoDirectory: () => _clearDirectory(isVideo: true),
+      ),
+    );
+  }
+
+  Future<void> _pickDirectory({
+    required String mediaType,
+    required Future<void> Function(String path) onSelected,
+  }) async {
+    try {
+      final path = await FilePicker.platform.getDirectoryPath(
+        dialogTitle: 'Select $mediaType download directory',
+      );
+      if (path == null) {
+        AppLogger.logInfo(
+          filename: 'lib/features/browser/views/browser_view.dart',
+          classname: '_BrowserViewState',
+          function: '_pickDirectory',
+          systemSection: 'settings',
+          message: 'User cancelled selecting $mediaType directory',
+        );
+        return;
+      }
+      await onSelected(path);
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/views/browser_view.dart',
+        classname: '_BrowserViewState',
+        function: '_pickDirectory',
+        systemSection: 'settings',
+        message: 'Selected default $mediaType directory: $path',
+      );
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/browser/views/browser_view.dart',
+        classname: '_BrowserViewState',
+        function: '_pickDirectory',
+        systemSection: 'settings',
+        message: 'Failed to pick $mediaType directory',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Failed to pick $mediaType directory'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  Future<void> _clearDirectory({required bool isVideo}) async {
+    if (isVideo) {
+      await _settingsController.setVideoSaveDirectory(null);
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/views/browser_view.dart',
+        classname: '_BrowserViewState',
+        function: '_clearDirectory',
+        systemSection: 'settings',
+        message: 'Cleared default video directory',
+      );
+    } else {
+      await _settingsController.setImageSaveDirectory(null);
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/views/browser_view.dart',
+        classname: '_BrowserViewState',
+        function: '_clearDirectory',
+        systemSection: 'settings',
+        message: 'Cleared default image directory',
+      );
+    }
   }
 
   Future<void> _downloadSelected() async {
@@ -298,6 +424,7 @@ class _ExtractionPanel extends StatelessWidget {
                       },
                     );
                   },
+                  onPreview: () => _showMediaPreview(context, item),
                 );
               },
             );
@@ -323,6 +450,20 @@ class _ExtractionPanel extends StatelessWidget {
       ),
     );
   }
+
+  Future<void> _showMediaPreview(BuildContext context, MediaItem item) async {
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/views/browser_view.dart',
+      classname: '_ExtractionPanel',
+      function: '_showMediaPreview',
+      systemSection: 'ui',
+      message: 'Opening preview for ${item.normalizedUrl}',
+    );
+    await showDialog<void>(
+      context: context,
+      builder: (context) => _MediaPreviewDialog(item: item),
+    );
+  }
 }
 
 class _MediaListTile extends StatelessWidget {
@@ -330,11 +471,13 @@ class _MediaListTile extends StatelessWidget {
     required this.item,
     required this.onToggleSelected,
     required this.onDownload,
+    required this.onPreview,
   });
 
   final MediaItem item;
   final VoidCallback onToggleSelected;
   final VoidCallback onDownload;
+  final VoidCallback onPreview;
 
   @override
   Widget build(BuildContext context) {
@@ -342,48 +485,64 @@ class _MediaListTile extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ListTile(
-        leading: _MediaThumbnail(item: item),
+        leading: GestureDetector(
+          onTap: onPreview,
+          child: _MediaThumbnail(item: item),
+        ),
         title: Text(
           item.normalizedUrl.toString(),
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
         ),
         subtitle: Text('${item.type.name.toUpperCase()} • ${item.contentLength ?? 0} bytes'),
-        trailing: Obx(() {
-          final progress = downloadController.taskProgress[item.id];
-          if (progress == null) {
-            return IconButton(
-              icon: const Icon(Icons.download),
-              onPressed: onDownload,
-            );
-          }
-          switch (progress.phase) {
-            case DownloadPhase.queued:
-              return const SizedBox(
-                width: 24,
-                height: 24,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              );
-            case DownloadPhase.inProgress:
-              return SizedBox(
-                width: 24,
-                height: 24,
-                child: CircularProgressIndicator(
-                  value: progress.progress == 0 ? null : progress.progress,
-                  strokeWidth: 2,
-                ),
-              );
-            case DownloadPhase.completed:
-              return const Icon(Icons.check_circle, color: Colors.green);
-            case DownloadPhase.failed:
-              return IconButton(
-                icon: const Icon(Icons.error, color: Colors.red),
-                onPressed: onDownload,
-              );
-          }
-        }),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Obx(() {
+              final progress = downloadController.taskProgress[item.id];
+              if (progress == null) {
+                return IconButton(
+                  icon: const Icon(Icons.download),
+                  tooltip: 'Download',
+                  onPressed: onDownload,
+                );
+              }
+              switch (progress.phase) {
+                case DownloadPhase.queued:
+                  return const SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  );
+                case DownloadPhase.inProgress:
+                  return SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(
+                      value:
+                          progress.progress == 0 ? null : progress.progress,
+                      strokeWidth: 2,
+                    ),
+                  );
+                case DownloadPhase.completed:
+                  return const Icon(Icons.check_circle, color: Colors.green);
+                case DownloadPhase.failed:
+                  return IconButton(
+                    icon: const Icon(Icons.error, color: Colors.red),
+                    tooltip: 'Retry download',
+                    onPressed: onDownload,
+                  );
+              }
+            }),
+            const SizedBox(width: 8),
+            Checkbox(
+              value: item.isSelected,
+              onChanged: (_) => onToggleSelected(),
+            ),
+          ],
+        ),
         selected: item.isSelected,
-        onTap: onToggleSelected,
+        onTap: onPreview,
       ),
     );
   }
@@ -399,20 +558,373 @@ class _MediaThumbnail extends StatelessWidget {
     final thumbnailUrl = item.thumbnailUrl ?? item.normalizedUrl;
     return ClipRRect(
       borderRadius: BorderRadius.circular(8),
+      child: item.bytes != null && item.type == MediaType.image
+          ? Image.memory(
+              item.bytes!,
+              width: 48,
+              height: 48,
+              fit: BoxFit.cover,
+            )
+          : Image.network(
+              thumbnailUrl.toString(),
+              width: 48,
+              height: 48,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) {
+                return Container(
+                  width: 48,
+                  height: 48,
+                  color: Colors.grey.shade300,
+                  alignment: Alignment.center,
+                  child: const Icon(Icons.broken_image),
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _DownloadSettingsSheet extends StatelessWidget {
+  const _DownloadSettingsSheet({
+    required this.settingsController,
+    required this.onPickImageDirectory,
+    required this.onPickVideoDirectory,
+    required this.onClearImageDirectory,
+    required this.onClearVideoDirectory,
+  });
+
+  final SettingsController settingsController;
+  final VoidCallback onPickImageDirectory;
+  final VoidCallback onPickVideoDirectory;
+  final VoidCallback onClearImageDirectory;
+  final VoidCallback onClearVideoDirectory;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 24, 16, 32),
+        child: Obx(() {
+          if (!settingsController.isReady.value) {
+            return const SizedBox(
+              height: 120,
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+          final state = settingsController.state.value;
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Download destinations',
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 16),
+              _DirectoryTile(
+                label: 'Images',
+                path: state.imageSaveDirectory,
+                onPick: onPickImageDirectory,
+                onClear: onClearImageDirectory,
+              ),
+              const SizedBox(height: 12),
+              _DirectoryTile(
+                label: 'Videos',
+                path: state.videoSaveDirectory,
+                onPick: onPickVideoDirectory,
+                onClear: onClearVideoDirectory,
+              ),
+            ],
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _DirectoryTile extends StatelessWidget {
+  const _DirectoryTile({
+    required this.label,
+    required this.path,
+    required this.onPick,
+    required this.onClear,
+  });
+
+  final String label;
+  final String? path;
+  final VoidCallback onPick;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasPath = path != null && path!.isNotEmpty;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '$label directory',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              hasPath ? path! : 'Not set',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (hasPath)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: TextButton(
+                      onPressed: onClear,
+                      child: const Text('Clear'),
+                    ),
+                  ),
+                FilledButton.icon(
+                  onPressed: onPick,
+                  icon: const Icon(Icons.folder_open),
+                  label: const Text('Choose'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MediaPreviewDialog extends StatefulWidget {
+  const _MediaPreviewDialog({required this.item});
+
+  final MediaItem item;
+
+  @override
+  State<_MediaPreviewDialog> createState() => _MediaPreviewDialogState();
+}
+
+class _MediaPreviewDialogState extends State<_MediaPreviewDialog> {
+  VideoPlayerController? _videoController;
+  Future<void>? _videoInitialization;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.item.type == MediaType.video) {
+      final controller = VideoPlayerController.networkUrl(
+        widget.item.normalizedUrl,
+      );
+      _videoController = controller;
+      _videoInitialization = controller.initialize();
+      _videoInitialization!.then((_) {
+        controller.setLooping(true);
+        AppLogger.logInfo(
+          filename: 'lib/features/browser/views/browser_view.dart',
+          classname: '_MediaPreviewDialogState',
+          function: 'initState',
+          systemSection: 'ui',
+          message: 'Video preview ready for ${widget.item.normalizedUrl}',
+        );
+        if (mounted) {
+          setState(() {});
+        }
+      }, onError: (error, stackTrace) {
+        AppLogger.logError(
+          filename: 'lib/features/browser/views/browser_view.dart',
+          classname: '_MediaPreviewDialogState',
+          function: 'initState',
+          systemSection: 'ui',
+          message: 'Failed to initialize video preview for ${widget.item.normalizedUrl}',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        if (mounted) {
+          setState(() {});
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _videoController?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final theme = Theme.of(context);
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 600),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      item.type == MediaType.video
+                          ? 'Video preview'
+                          : 'Image preview',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                height: 360,
+                width: double.infinity,
+                child: _buildPreviewBody(),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  item.normalizedUrl.toString(),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPreviewBody() {
+    switch (widget.item.type) {
+      case MediaType.image:
+        return _buildImagePreview();
+      case MediaType.video:
+        return _buildVideoPreview();
+      case MediaType.streaming:
+        return _buildUnsupportedPreview(
+          'Preview is not available for streaming media.',
+        );
+    }
+  }
+
+  Widget _buildImagePreview() {
+    final item = widget.item;
+    if (item.bytes != null) {
+      return InteractiveViewer(
+        child: Image.memory(
+          item.bytes!,
+          fit: BoxFit.contain,
+        ),
+      );
+    }
+    return InteractiveViewer(
       child: Image.network(
-        thumbnailUrl.toString(),
-        width: 48,
-        height: 48,
-        fit: BoxFit.cover,
+        item.normalizedUrl.toString(),
+        fit: BoxFit.contain,
+        loadingBuilder: (context, child, progress) {
+          if (progress == null) {
+            return child;
+          }
+          return const Center(child: CircularProgressIndicator());
+        },
         errorBuilder: (context, error, stackTrace) {
-          return Container(
-            width: 48,
-            height: 48,
-            color: Colors.grey.shade300,
-            alignment: Alignment.center,
-            child: const Icon(Icons.broken_image),
+          AppLogger.logError(
+            filename: 'lib/features/browser/views/browser_view.dart',
+            classname: '_MediaPreviewDialogState',
+            function: '_buildImagePreview',
+            systemSection: 'ui',
+            message:
+                'Failed to load image preview for ${item.normalizedUrl}',
+            error: error,
+            stackTrace: stackTrace,
+          );
+          return _buildUnsupportedPreview(
+            'Unable to load image preview.',
           );
         },
+      ),
+    );
+  }
+
+  Widget _buildVideoPreview() {
+    final controller = _videoController;
+    final initialization = _videoInitialization;
+    if (controller == null || initialization == null) {
+      return _buildUnsupportedPreview('Video preview is unavailable.');
+    }
+    return FutureBuilder<void>(
+      future: initialization,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return _buildUnsupportedPreview('Unable to load video preview.');
+        }
+        final aspectRatio = controller.value.aspectRatio == 0
+            ? 16 / 9
+            : controller.value.aspectRatio;
+        return Column(
+          children: [
+            Expanded(
+              child: AspectRatio(
+                aspectRatio: aspectRatio,
+                child: VideoPlayer(controller),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                IconButton(
+                  icon: Icon(
+                    controller.value.isPlaying
+                        ? Icons.pause
+                        : Icons.play_arrow,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      if (controller.value.isPlaying) {
+                        controller.pause();
+                      } else {
+                        controller.play();
+                      }
+                    });
+                  },
+                ),
+                Expanded(
+                  child: VideoProgressIndicator(
+                    controller,
+                    allowScrubbing: true,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildUnsupportedPreview(String message) {
+    return Center(
+      child: Text(
+        message,
+        textAlign: TextAlign.center,
       ),
     );
   }

--- a/mobile/lib/features/settings/controllers/settings_controller.dart
+++ b/mobile/lib/features/settings/controllers/settings_controller.dart
@@ -81,4 +81,12 @@ class SettingsController extends GetxController {
   Future<void> toggleAutoplayThumbnails(bool enabled) => updateSettings(
         state.value.copyWith(includeAutoplayThumbnails: enabled),
       );
+
+  Future<void> setImageSaveDirectory(String? path) => updateSettings(
+        state.value.copyWith(imageSaveDirectory: path),
+      );
+
+  Future<void> setVideoSaveDirectory(String? path) => updateSettings(
+        state.value.copyWith(videoSaveDirectory: path),
+      );
 }

--- a/mobile/lib/features/settings/models/settings_state.dart
+++ b/mobile/lib/features/settings/models/settings_state.dart
@@ -6,6 +6,8 @@ class SettingsState {
     required this.includeSvg,
     required this.includeGif,
     required this.includeAutoplayThumbnails,
+    this.imageSaveDirectory,
+    this.videoSaveDirectory,
   });
 
   factory SettingsState.initial() => const SettingsState(
@@ -15,6 +17,8 @@ class SettingsState {
         includeSvg: true,
         includeGif: true,
         includeAutoplayThumbnails: false,
+        imageSaveDirectory: null,
+        videoSaveDirectory: null,
       );
 
   factory SettingsState.fromJson(Map<String, dynamic> json) => SettingsState(
@@ -24,6 +28,8 @@ class SettingsState {
         includeSvg: json['includeSvg'] as bool? ?? true,
         includeGif: json['includeGif'] as bool? ?? true,
         includeAutoplayThumbnails: json['includeAutoplayThumbnails'] as bool? ?? false,
+        imageSaveDirectory: json['imageSaveDirectory'] as String?,
+        videoSaveDirectory: json['videoSaveDirectory'] as String?,
       );
 
   final int minImageBytes;
@@ -32,6 +38,8 @@ class SettingsState {
   final bool includeSvg;
   final bool includeGif;
   final bool includeAutoplayThumbnails;
+  final String? imageSaveDirectory;
+  final String? videoSaveDirectory;
 
   SettingsState copyWith({
     int? minImageBytes,
@@ -40,6 +48,8 @@ class SettingsState {
     bool? includeSvg,
     bool? includeGif,
     bool? includeAutoplayThumbnails,
+    Object? imageSaveDirectory = _sentinel,
+    Object? videoSaveDirectory = _sentinel,
   }) =>
       SettingsState(
         minImageBytes: minImageBytes ?? this.minImageBytes,
@@ -49,6 +59,12 @@ class SettingsState {
         includeGif: includeGif ?? this.includeGif,
         includeAutoplayThumbnails:
             includeAutoplayThumbnails ?? this.includeAutoplayThumbnails,
+        imageSaveDirectory: imageSaveDirectory == _sentinel
+            ? this.imageSaveDirectory
+            : imageSaveDirectory as String?,
+        videoSaveDirectory: videoSaveDirectory == _sentinel
+            ? this.videoSaveDirectory
+            : videoSaveDirectory as String?,
       );
 
   Map<String, dynamic> toJson() => <String, dynamic>{
@@ -58,6 +74,8 @@ class SettingsState {
         'includeSvg': includeSvg,
         'includeGif': includeGif,
         'includeAutoplayThumbnails': includeAutoplayThumbnails,
+        'imageSaveDirectory': imageSaveDirectory,
+        'videoSaveDirectory': videoSaveDirectory,
       };
 
   @override
@@ -71,7 +89,9 @@ class SettingsState {
         other.concurrentDownloads == concurrentDownloads &&
         other.includeSvg == includeSvg &&
         other.includeGif == includeGif &&
-        other.includeAutoplayThumbnails == includeAutoplayThumbnails;
+        other.includeAutoplayThumbnails == includeAutoplayThumbnails &&
+        other.imageSaveDirectory == imageSaveDirectory &&
+        other.videoSaveDirectory == videoSaveDirectory;
   }
 
   @override
@@ -82,5 +102,9 @@ class SettingsState {
         includeSvg,
         includeGif,
         includeAutoplayThumbnails,
+        imageSaveDirectory,
+        videoSaveDirectory,
       );
 }
+
+const Object _sentinel = Object();

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   webview_flutter: ^4.7.0
   html: ^0.15.4
   shared_preferences: ^2.2.2
+  file_picker: ^6.1.1
+  video_player: ^2.8.6
 
 dev_dependencies:
   flutter_test:

--- a/mobile/test/settings_state_test.dart
+++ b/mobile/test/settings_state_test.dart
@@ -14,10 +14,29 @@ void main() {
     });
 
     test('serializes to and from json', () {
-      const state = SettingsState.initial();
+      final state = SettingsState.initial().copyWith(
+        imageSaveDirectory: '/tmp/images',
+        videoSaveDirectory: '/tmp/videos',
+      );
       final json = state.toJson();
       final parsed = SettingsState.fromJson(json);
       expect(parsed, equals(state));
+    });
+
+    test('copyWith updates download directories', () {
+      const state = SettingsState.initial();
+      final updated = state.copyWith(
+        imageSaveDirectory: '/data/images',
+        videoSaveDirectory: '/data/videos',
+      );
+      expect(updated.imageSaveDirectory, '/data/images');
+      expect(updated.videoSaveDirectory, '/data/videos');
+      final cleared = updated.copyWith(
+        imageSaveDirectory: null,
+        videoSaveDirectory: null,
+      );
+      expect(cleared.imageSaveDirectory, isNull);
+      expect(cleared.videoSaveDirectory, isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add toolbar controls to hide the browser address bar and open download destination settings
- persist default image and video download directories and expose them through the settings controller and tests
- enable in-app media previews for extracted items, including video playback, and refresh thumbnails when bytes are available

## Testing
- `flutter pub get` *(fails: flutter executable is unavailable in the environment)*
- `flutter test` *(fails: flutter executable is unavailable in the environment)*
- `flutter analyze` *(fails: flutter executable is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cda1b698832ba96a5937a6f0305c