### PR TITLE
Add bookmarked history and persistence to mobile browser

### DIFF
--- a/mobile/lib/core/bindings/app_bindings.dart
+++ b/mobile/lib/core/bindings/app_bindings.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:get/get.dart';
 
 import '../network/dio_client.dart';
+import '../storage/browser_storage.dart';
 import '../storage/settings_storage.dart';
 import '../../features/browser/controllers/browser_controller.dart';
 import '../../features/download/controllers/download_controller.dart';
@@ -19,6 +20,11 @@ class AppBindings extends Bindings {
       return controller;
     }, permanent: true);
 
+    Get.putAsync<BrowserStorage>(
+      () => const BrowserStorageFactory().create(),
+      permanent: true,
+    );
+
     Get.lazyPut<ExtractionController>(
       () => ExtractionController(Get.find<Dio>()),
       fenix: true,
@@ -28,7 +34,10 @@ class AppBindings extends Bindings {
       fenix: true,
     );
     Get.lazyPut<BrowserController>(
-      () => BrowserController(Get.find<ExtractionController>()),
+      () => BrowserController(
+        Get.find<ExtractionController>(),
+        Get.find<BrowserStorage>(),
+      ),
       fenix: true,
     );
   }

--- a/mobile/lib/core/storage/browser_storage.dart
+++ b/mobile/lib/core/storage/browser_storage.dart
@@ -1,0 +1,123 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../logging/app_logger.dart';
+
+abstract class BrowserStorage {
+  Future<List<Uri>> loadFavorites();
+  Future<void> saveFavorites(List<Uri> favorites);
+  Future<Uri?> loadLastVisited();
+  Future<void> saveLastVisited(Uri? uri);
+}
+
+class SharedPreferencesBrowserStorage implements BrowserStorage {
+  SharedPreferencesBrowserStorage(this._preferences);
+
+  final SharedPreferences _preferences;
+
+  static const _favoritesKey = 'browser_favorites';
+  static const _lastVisitedKey = 'browser_last_url';
+
+  @override
+  Future<List<Uri>> loadFavorites() async {
+    final stored = _preferences.getStringList(_favoritesKey);
+    if (stored == null) {
+      return const [];
+    }
+
+    final uris = <Uri>[];
+    for (final entry in stored) {
+      try {
+        uris.add(Uri.parse(entry));
+      } catch (_) {
+        AppLogger.logError(
+          filename: 'lib/core/storage/browser_storage.dart',
+          classname: 'SharedPreferencesBrowserStorage',
+          function: 'loadFavorites',
+          systemSection: 'browser',
+          message: 'Skipped invalid favorite entry',
+          error: entry,
+        );
+      }
+    }
+    return uris;
+  }
+
+  @override
+  Future<void> saveFavorites(List<Uri> favorites) async {
+    final encoded = favorites.map((uri) => uri.toString()).toList(growable: false);
+    await _preferences.setStringList(_favoritesKey, encoded);
+  }
+
+  @override
+  Future<Uri?> loadLastVisited() async {
+    final stored = _preferences.getString(_lastVisitedKey);
+    if (stored == null) {
+      return null;
+    }
+    try {
+      return Uri.parse(stored);
+    } catch (error) {
+      AppLogger.logError(
+        filename: 'lib/core/storage/browser_storage.dart',
+        classname: 'SharedPreferencesBrowserStorage',
+        function: 'loadLastVisited',
+        systemSection: 'browser',
+        message: 'Failed to parse stored last visited URL',
+        error: error,
+      );
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveLastVisited(Uri? uri) async {
+    if (uri == null) {
+      await _preferences.remove(_lastVisitedKey);
+      return;
+    }
+    await _preferences.setString(_lastVisitedKey, uri.toString());
+  }
+}
+
+class InMemoryBrowserStorage implements BrowserStorage {
+  List<Uri> _favorites = const [];
+  Uri? _lastVisited;
+
+  @override
+  Future<List<Uri>> loadFavorites() async => _favorites;
+
+  @override
+  Future<void> saveFavorites(List<Uri> favorites) async {
+    _favorites = List<Uri>.from(favorites);
+  }
+
+  @override
+  Future<Uri?> loadLastVisited() async => _lastVisited;
+
+  @override
+  Future<void> saveLastVisited(Uri? uri) async {
+    _lastVisited = uri;
+  }
+}
+
+class BrowserStorageFactory {
+  const BrowserStorageFactory();
+
+  Future<BrowserStorage> create() async {
+    try {
+      final preferences = await SharedPreferences.getInstance();
+      return SharedPreferencesBrowserStorage(preferences);
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/core/storage/browser_storage.dart',
+        classname: 'BrowserStorageFactory',
+        function: 'create',
+        systemSection: 'browser',
+        message: 'Falling back to in-memory browser storage',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return InMemoryBrowserStorage();
+    }
+  }
+}

--- a/mobile/lib/features/browser/controllers/browser_controller.dart
+++ b/mobile/lib/features/browser/controllers/browser_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -5,21 +7,78 @@ import 'package:webview_flutter/webview_flutter.dart';
 import '../../../core/errors/app_error.dart';
 import '../../../core/logging/app_logger.dart';
 import '../../../core/result/app_result.dart';
+import '../../../core/storage/browser_storage.dart';
 import '../../../core/utils/uri_utils.dart';
 import '../../extract/controllers/extraction_controller.dart';
 
 class BrowserController extends GetxController {
-  BrowserController(this._extractionController);
+  BrowserController(this._extractionController, this._storage);
 
   final ExtractionController _extractionController;
+  final BrowserStorage _storage;
 
   final TextEditingController urlController = TextEditingController();
   final Rxn<Uri> currentUrl = Rxn<Uri>();
   final RxnString validationError = RxnString();
   final RxBool isLoading = false.obs;
   final RxBool showControls = true.obs;
+  final RxList<Uri> favorites = <Uri>[].obs;
+  final RxBool isCurrentBookmarked = false.obs;
 
   WebViewController? _webViewController;
+  Worker? _currentUrlWorker;
+  Uri? _pendingInitialUrl;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _currentUrlWorker = ever<Uri?>(currentUrl, _handleCurrentUrlChanged);
+    _initializeState();
+  }
+
+  Future<void> _initializeState() async {
+    try {
+      final storedFavorites = await _storage.loadFavorites();
+      final normalizedFavorites = storedFavorites
+          .map(UriUtils.normalize)
+          .toSet()
+          .toList()
+        ..sort((a, b) => a.toString().compareTo(b.toString()));
+      favorites.assignAll(normalizedFavorites);
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: '_initializeState',
+        systemSection: 'browser',
+        message: 'Restored ${favorites.length} favorite URLs',
+      );
+
+      final lastVisited = await _storage.loadLastVisited();
+      if (lastVisited != null) {
+        final normalized = UriUtils.normalize(lastVisited);
+        _pendingInitialUrl = normalized;
+        currentUrl.value = normalized;
+        urlController.text = normalized.toString();
+        AppLogger.logInfo(
+          filename: 'lib/features/browser/controllers/browser_controller.dart',
+          classname: 'BrowserController',
+          function: '_initializeState',
+          systemSection: 'browser',
+          message: 'Restored last visited URL $normalized',
+        );
+      }
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: '_initializeState',
+        systemSection: 'browser',
+        message: 'Failed to restore browser state',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
 
   void attachWebViewController(WebViewController controller) {
     _webViewController = controller;
@@ -30,6 +89,39 @@ class BrowserController extends GetxController {
       systemSection: 'browser',
       message: 'Attached WebViewController instance',
     );
+
+    final initialUrl = _pendingInitialUrl;
+    if (initialUrl != null) {
+      _pendingInitialUrl = null;
+      unawaited(_loadInitialUrl(controller, initialUrl));
+    }
+  }
+
+  Future<void> _loadInitialUrl(
+    WebViewController controller,
+    Uri url,
+  ) async {
+    try {
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: '_loadInitialUrl',
+        systemSection: 'browser',
+        message: 'Loading restored URL $url',
+        method: 'GET',
+      );
+      await controller.loadRequest(url);
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: '_loadInitialUrl',
+        systemSection: 'browser',
+        message: 'Failed to load restored URL $url',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   Future<void> openCurrentUrl() async {
@@ -46,7 +138,7 @@ class BrowserController extends GetxController {
     }
 
     validationError.value = null;
-    final target = Uri.parse(normalized);
+    final target = UriUtils.normalize(Uri.parse(normalized));
     currentUrl.value = target;
     final controller = _webViewController;
     if (controller == null) {
@@ -63,6 +155,34 @@ class BrowserController extends GetxController {
     isLoading.value = true;
     await controller.loadRequest(target);
     isLoading.value = false;
+  }
+
+  void updateCurrentUrlFromWebView(String url) {
+    final parsed = Uri.tryParse(url);
+    if (parsed == null) {
+      AppLogger.logDebug(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'updateCurrentUrlFromWebView',
+        systemSection: 'browser',
+        message: 'Ignored malformed URL reported by web view: $url',
+      );
+      return;
+    }
+
+    final scheme = parsed.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      AppLogger.logDebug(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'updateCurrentUrlFromWebView',
+        systemSection: 'browser',
+        message: 'Ignored non-http URL reported by web view: $url',
+      );
+      return;
+    }
+
+    currentUrl.value = UriUtils.normalize(parsed);
   }
 
   Future<AppResult<void>> processCurrentPage() async {
@@ -97,6 +217,146 @@ class BrowserController extends GetxController {
     );
   }
 
+  Future<void> toggleBookmark() async {
+    final url = currentUrl.value;
+    if (url == null) {
+      AppLogger.logDebug(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'toggleBookmark',
+        systemSection: 'browser',
+        message: 'Ignoring bookmark toggle with no active URL',
+      );
+      return;
+    }
+
+    final normalized = UriUtils.normalize(url);
+    final exists = favorites.any((uri) => uri == normalized);
+    if (exists) {
+      favorites.removeWhere((uri) => uri == normalized);
+      isCurrentBookmarked.value = false;
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'toggleBookmark',
+        systemSection: 'browser',
+        message: 'Removed favorite URL $normalized',
+      );
+    } else {
+      favorites.add(normalized);
+      favorites.sort((a, b) => a.toString().compareTo(b.toString()));
+      isCurrentBookmarked.value = true;
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'toggleBookmark',
+        systemSection: 'browser',
+        message: 'Added favorite URL $normalized',
+      );
+    }
+
+    await _persistFavorites();
+  }
+
+  Future<void> openFromFavorites(Uri target) async {
+    final normalized = UriUtils.normalize(target);
+    urlController.text = normalized.toString();
+    currentUrl.value = normalized;
+
+    final controller = _webViewController;
+    if (controller == null) {
+      _pendingInitialUrl = normalized;
+      AppLogger.logDebug(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'openFromFavorites',
+        systemSection: 'browser',
+        message: 'Deferring load of $normalized until WebView is ready',
+      );
+      return;
+    }
+
+    try {
+      AppLogger.logInfo(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'openFromFavorites',
+        systemSection: 'browser',
+        message: 'Loading favorite URL $normalized',
+        method: 'GET',
+      );
+      isLoading.value = true;
+      await controller.loadRequest(normalized);
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: 'openFromFavorites',
+        systemSection: 'browser',
+        message: 'Failed to load favorite URL $normalized',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> _persistFavorites() async {
+    try {
+      await _storage.saveFavorites(List<Uri>.from(favorites));
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: '_persistFavorites',
+        systemSection: 'browser',
+        message: 'Failed to persist favorite URLs',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _handleCurrentUrlChanged(Uri? uri) async {
+    if (uri == null) {
+      isCurrentBookmarked.value = false;
+      try {
+        await _storage.saveLastVisited(null);
+      } catch (error, stackTrace) {
+        AppLogger.logError(
+          filename: 'lib/features/browser/controllers/browser_controller.dart',
+          classname: 'BrowserController',
+          function: '_handleCurrentUrlChanged',
+          systemSection: 'browser',
+          message: 'Failed to clear last visited URL',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+      return;
+    }
+
+    final normalized = UriUtils.normalize(uri);
+    final bookmarked = favorites.any((item) => item == normalized);
+    isCurrentBookmarked.value = bookmarked;
+
+    try {
+      await _storage.saveLastVisited(normalized);
+    } catch (error, stackTrace) {
+      AppLogger.logError(
+        filename: 'lib/features/browser/controllers/browser_controller.dart',
+        classname: 'BrowserController',
+        function: '_handleCurrentUrlChanged',
+        systemSection: 'browser',
+        message: 'Failed to persist last visited URL $normalized',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
   String? _normalizeInput(String input) {
     final withScheme = input.contains('://') ? input : 'https://$input';
     try {
@@ -108,6 +368,7 @@ class BrowserController extends GetxController {
 
   @override
   void onClose() {
+    _currentUrlWorker?.dispose();
     urlController.dispose();
     super.onClose();
   }

--- a/mobile/lib/features/browser/views/browser_view.dart
+++ b/mobile/lib/features/browser/views/browser_view.dart
@@ -1,5 +1,6 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:video_player/video_player.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -41,11 +42,11 @@ class _BrowserViewState extends State<BrowserView> {
         NavigationDelegate(
           onPageStarted: (url) {
             _browserController.isLoading.value = true;
-            _browserController.currentUrl.value = Uri.tryParse(url);
+            _browserController.updateCurrentUrlFromWebView(url);
           },
           onPageFinished: (url) {
             _browserController.isLoading.value = false;
-            _browserController.currentUrl.value = Uri.tryParse(url);
+            _browserController.updateCurrentUrlFromWebView(url);
           },
           onWebResourceError: (error) {
             final appError = UnknownError(
@@ -71,6 +72,19 @@ class _BrowserViewState extends State<BrowserView> {
               icon: Icon(isVisible ? Icons.menu_open : Icons.menu),
               tooltip: isVisible ? 'Hide address bar' : 'Show address bar',
               onPressed: _browserController.toggleControlsVisibility,
+            );
+          }),
+          IconButton(
+            icon: const Icon(Icons.menu_book),
+            tooltip: 'Show bookmarks',
+            onPressed: _showFavorites,
+          ),
+          Obx(() {
+            final hasUrl = _browserController.currentUrl.value != null;
+            return IconButton(
+              icon: const Icon(Icons.copy),
+              tooltip: 'Copy current link',
+              onPressed: hasUrl ? _copyCurrentLink : null,
             );
           }),
           Obx(() {
@@ -162,6 +176,134 @@ class _BrowserViewState extends State<BrowserView> {
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _showFavorites() async {
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/views/browser_view.dart',
+      classname: '_BrowserViewState',
+      function: '_showFavorites',
+      systemSection: 'browser',
+      message: 'Opening favorites sheet',
+    );
+    if (!mounted) {
+      return;
+    }
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Obx(() {
+              final favorites =
+                  _browserController.favorites.toList(growable: false);
+              if (favorites.isEmpty) {
+                return const SizedBox(
+                  height: 200,
+                  child: Center(
+                    child: Text('No bookmarked pages yet.'),
+                  ),
+                );
+              }
+              return SizedBox(
+                height: 360,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Text(
+                      'Bookmarked pages',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Expanded(
+                      child: ListView.separated(
+                        itemBuilder: (context, index) {
+                          final url = favorites[index];
+                          return ListTile(
+                            leading: const Icon(
+                              Icons.star,
+                              color: Colors.amber,
+                            ),
+                            title: Text(
+                              url.toString(),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            trailing: const Icon(Icons.open_in_new),
+                            onTap: () async {
+                              Navigator.of(sheetContext).pop();
+                              AppLogger.logInfo(
+                                filename:
+                                    'lib/features/browser/views/browser_view.dart',
+                                classname: '_BrowserViewState',
+                                function: '_showFavorites',
+                                systemSection: 'browser',
+                                message: 'Opening bookmarked URL $url',
+                              );
+                              try {
+                                await _browserController.openFromFavorites(url);
+                              } catch (_) {
+                                if (!mounted) {
+                                  return;
+                                }
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text(
+                                      'Failed to open ${url.toString()}',
+                                    ),
+                                    backgroundColor: Colors.red,
+                                  ),
+                                );
+                              }
+                            },
+                          );
+                        },
+                        separatorBuilder: (_, __) => const Divider(height: 1),
+                        itemCount: favorites.length,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _copyCurrentLink() async {
+    final url = _browserController.currentUrl.value;
+    if (url == null) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Open a page before copying the link.'),
+        ),
+      );
+      return;
+    }
+    await Clipboard.setData(ClipboardData(text: url.toString()));
+    AppLogger.logInfo(
+      filename: 'lib/features/browser/views/browser_view.dart',
+      classname: '_BrowserViewState',
+      function: '_copyCurrentLink',
+      systemSection: 'browser',
+      message: 'Copied current URL $url to clipboard',
+    );
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Link copied to clipboard')),
     );
   }
 
@@ -299,6 +441,8 @@ class _UrlInputBar extends StatelessWidget {
 
   final BrowserController controller;
 
+  static const double _actionButtonWidth = 120;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -319,29 +463,53 @@ class _UrlInputBar extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 12),
-              FilledButton(
-                onPressed: controller.openCurrentUrl,
-                child: const Text('Open'),
+              SizedBox(
+                width: _actionButtonWidth,
+                child: FilledButton(
+                  onPressed: controller.openCurrentUrl,
+                  child: const Text('Open'),
+                ),
               ),
               const SizedBox(width: 12),
-              FilledButton.icon(
-                onPressed: () async {
-                  final result = await controller.processCurrentPage();
-                  result.when(
-                    success: (_) {},
-                    failure: (error) {
-                      Get.snackbar(
-                        'Processing failed',
-                        error.message,
-                        backgroundColor: Colors.red.shade700,
-                        colorText: Colors.white,
-                      );
-                    },
-                  );
-                },
-                icon: const Icon(Icons.auto_awesome),
-                label: const Text('Process'),
+              SizedBox(
+                width: _actionButtonWidth,
+                child: FilledButton.icon(
+                  onPressed: () async {
+                    final result = await controller.processCurrentPage();
+                    result.when(
+                      success: (_) {},
+                      failure: (error) {
+                        Get.snackbar(
+                          'Processing failed',
+                          error.message,
+                          backgroundColor: Colors.red.shade700,
+                          colorText: Colors.white,
+                        );
+                      },
+                    );
+                  },
+                  icon: const Icon(Icons.auto_awesome),
+                  label: const Text('Process'),
+                ),
               ),
+              const SizedBox(width: 8),
+              Obx(() {
+                final isBookmarked = controller.isCurrentBookmarked.value;
+                final hasUrl = controller.currentUrl.value != null;
+                return IconButton(
+                  tooltip:
+                      isBookmarked ? 'Remove bookmark' : 'Bookmark this page',
+                  icon: Icon(
+                    isBookmarked ? Icons.star : Icons.star_border,
+                    color: isBookmarked ? Colors.amber : null,
+                  ),
+                  onPressed: hasUrl
+                      ? () {
+                          controller.toggleBookmark();
+                        }
+                      : null,
+                );
+              }),
             ],
           ),
           Obx(() {

--- a/mobile/test/browser_controller_test.dart
+++ b/mobile/test/browser_controller_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'package:butterknife_app/core/storage/browser_storage.dart';
+import 'package:butterknife_app/core/utils/uri_utils.dart';
+import 'package:butterknife_app/features/browser/controllers/browser_controller.dart';
+import 'package:butterknife_app/features/extract/controllers/extraction_controller.dart';
+
+class _MockExtractionController extends Mock implements ExtractionController {}
+
+class _MockWebViewController extends Mock implements WebViewController {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() {
+    registerFallbackValue(Uri.parse('https://fallback.test'));
+  });
+
+  late ExtractionController extractionController;
+  late InMemoryBrowserStorage storage;
+  late BrowserController controller;
+
+  setUp(() {
+    extractionController = _MockExtractionController();
+    storage = InMemoryBrowserStorage();
+    controller = BrowserController(extractionController, storage);
+    controller.onInit();
+  });
+
+  tearDown(() {
+    controller.onClose();
+  });
+
+  Future<void> _pumpController() async {
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  test('restores favorites and last visited URL on init', () async {
+    await storage.saveFavorites([Uri.parse('https://example.com')]);
+    await storage.saveLastVisited(Uri.parse('https://flutter.dev'));
+
+    final restoredController = BrowserController(extractionController, storage);
+    restoredController.onInit();
+    await _pumpController();
+
+    expect(restoredController.favorites.length, 1);
+    expect(restoredController.favorites.first.toString(), 'https://example.com');
+    expect(restoredController.currentUrl.value?.toString(), 'https://flutter.dev');
+    expect(restoredController.urlController.text, 'https://flutter.dev');
+    expect(restoredController.isCurrentBookmarked.value, isFalse);
+    restoredController.onClose();
+  });
+
+  test('toggleBookmark adds and removes favorites and persists state', () async {
+    controller.currentUrl.value = Uri.parse('https://example.com/path');
+    await _pumpController();
+    expect(controller.isCurrentBookmarked.value, isFalse);
+
+    await controller.toggleBookmark();
+    await _pumpController();
+    expect(controller.isCurrentBookmarked.value, isTrue);
+    expect(controller.favorites.map((uri) => uri.toString()),
+        contains('https://example.com/path'));
+    final storedAfterAdd = await storage.loadFavorites();
+    expect(storedAfterAdd.map((uri) => uri.toString()),
+        contains('https://example.com/path'));
+
+    await controller.toggleBookmark();
+    await _pumpController();
+    expect(controller.isCurrentBookmarked.value, isFalse);
+    final storedAfterRemove = await storage.loadFavorites();
+    expect(storedAfterRemove, isEmpty);
+  });
+
+  test('updateCurrentUrlFromWebView ignores invalid and non-http URLs', () {
+    controller.updateCurrentUrlFromWebView('not a url');
+    expect(controller.currentUrl.value, isNull);
+
+    controller.updateCurrentUrlFromWebView('about:blank');
+    expect(controller.currentUrl.value, isNull);
+
+    controller.updateCurrentUrlFromWebView('https://example.com/?b=2&a=1');
+    expect(controller.currentUrl.value?.toString(),
+        equals(UriUtils.normalize(Uri.parse('https://example.com/?b=2&a=1')).toString()));
+  });
+
+  test('openFromFavorites loads URL through web view when available', () async {
+    final webView = _MockWebViewController();
+    when(() => webView.loadRequest(any())).thenAnswer((_) async {});
+
+    controller.attachWebViewController(webView);
+    await controller.openFromFavorites(Uri.parse('https://example.com/?b=2&a=1'));
+
+    final expected = UriUtils.normalize(Uri.parse('https://example.com/?b=2&a=1'));
+    verify(() => webView.loadRequest(expected)).called(1);
+    expect(controller.currentUrl.value, expected);
+    expect(controller.urlController.text, expected.toString());
+  });
+
+  test('current URL changes persist the last visited URL', () async {
+    final target = Uri.parse('https://flutter.dev/docs');
+    controller.currentUrl.value = target;
+    await _pumpController();
+
+    final stored = await storage.loadLastVisited();
+    expect(stored, UriUtils.normalize(target));
+  });
+}

--- a/task.md
+++ b/task.md
@@ -1,0 +1,6 @@
+# Project Tasks
+
+- [x] Implement bookmarked history UI and controls in the browser view.
+- [x] Persist favorites and last visited page across sessions.
+- [x] Add copy link action and align action button widths.
+- [ ] Run Flutter analysis and tests. _(Blocked: `flutter` tool is unavailable in the container environment.)_


### PR DESCRIPTION
## Summary
- add a shared_preferences-backed browser storage layer and wire it into the app bindings so favorites and last visited pages persist
- enhance the browser controller and view with bookmarking, a favorites bottom sheet, copy-link action, and aligned action button widths
- cover the new behaviour with controller unit tests and track task progress in task.md

## Testing
- pytest
- ruff check .
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fc1713b4832bb756f227f825c591